### PR TITLE
Import draft spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# IDE
+.idea/
+.vscode/
+
+# Mac
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # CDEvents
 
-Coming soon!
-
-Our draft spec is available on the [SIG Events repo](https://github.com/cdfoundation/sig-events/tree/main/vocabulary-draft).
+We are working on a draft version of our specification that is not yet ready for implementation. For more information check out our [spec](./spec.md)

--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -1,0 +1,27 @@
+# Continuous Deployment Pipelines Events
+
+__Note:__ This is a work-in-progress draft version and is being worked on by members of the Events SIG. You are very welcome to join the work and the discussions!
+
+These events are related to continuos deployment pipelines and their target environments.
+These events can be emitted by environments to report where software artifacts such as services, binaries, daemons, jobs or embedded software are running.
+
+The term Service is used to represent a running Artifact. This service can represent a binary that is running, a daemon, an application, a docker container, etc.
+The term Environment represent any platform which has all the means to run a Service.
+
+- **Environment Created**: an environment has been created and it can be used to deploy Services
+- **Environment Modified**: an environment has been modified, this event advertise the changes made in the environment
+- **Environment Deleted**: an environment has been deleted and cannot longer be used
+- **Service Deployed**: a new instance of the Service has been deployed
+- **Service Upgraded**: an existing instance of a Service has been upgraded to a new version
+- **Service Rolledback**: an existing instance of a Service has been rolledback to a previous version
+- **Service Removed**: an existing instance of a Service has been terminated an it is not longer present in an environment
+
+Continuous Deployment Events MUST include the following attributes:
+
+- **Event Type**: the type is restricted to include `cd.**` prefix. For example `cd.service.upgraded` or `cd.environment.created`
+- **Environment ID**: unique identifier for the Environment
+
+Optional attributes:
+
+- **Environment Name**: user-friendly name for the environment, to be displayed in tools or User Interfaces
+- **Environment URL**: URL to reference where the environment is located

--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -1,0 +1,32 @@
+# Continuous Integration Events
+
+__Note:__ This is a work-in-progress draft version and is being worked on by members of the Events SIG. You are very welcome to join the work and the discussions!
+
+These events are related to **Continuous Integration(CI)** activities. CI usually include activities such as building, testing, packaging and releasing software artifacts.
+
+The following events represent concrete Tasks that are associated with the execution of CI pipelines:
+
+- **Build Queued**: a Build task has been queued, this build process usually is in charge of producing a binary from source code
+- **Build Started**: a Build task has started
+- **Build Finished**: a Build task has finished, the event will contain the finished status, success, error or failure
+
+The following Test events are defined in two separate categories **Test Case** and **Test Suite**. A **Test Case** is the smallest unit of testing that the user wants to track. A **Test Suite** is a collection of test case executions and/or other test suite executions. **Test Cases** executed, and Test Suites are for grouping purposes. For this reason, **Test Cases** can be queued.
+
+- **Test Case Queued**: a Test task has been queued, and it is waiting to be started
+- **Test Case Started**: a Test task has started
+- **Test Case Finished**: a Test task has finished, the event will contain the finished status: success, error or failure
+- **Test Suite Started**: a Test Suite has started
+- **Test Suite Finished**: a Test Suite has finished, the event will contain the finished status: success, error or failure
+
+Finally, events needs to be generated for the output of the pipeline such as the artifacts that were packaged and released for others to use.
+
+- **Artifact Packaged**: an artifact has been packaged for distribution, this artifact is now versioned with a fixed version
+- **Artifact Published**: an artifact has been published and it can be advertised for others to use
+
+CI Events MUST include the following attributes:
+
+- **Event Type**: the type is restricted to include `cd.**` prefix. For example `cd.build.queued` or `cd.artifact.packaged`
+
+Optional attributes:
+
+- **Artifact Id**: the unique identifier of the artifact that the event is referring to.

--- a/core.md
+++ b/core.md
@@ -1,0 +1,32 @@
+# Continuous Delivery Core Events
+
+__Note:__ This is a work-in-progress draft version and is being worked on by members of the Events SIG. You are very welcome to join the work and the discussions!
+
+Continuous Delivery related to activities and orchestration that needs to exist to be able to deterministically and continuously being able to delivery software to users.
+
+A pipeline, in the context of Continuous Delivery, is the definition of a set of tasks that needs to be performed to build, test, package, release and deploy software artifacts.
+A pipeline can be instantiated multiple times, for example to build different versions of the same artifact.
+We are referring to this instance as PipelineRun. It will have a unique Id and it will help us to track the build and release progress on a particular software artifact.
+
+Due the dynamic nature of Pipelines, most of actual work needs to be queued to happen in a distributed way, hence Queued events are added. Adopters can choose to ignore these events if they don't apply to their use cases.
+
+- **PipelineRun Queued**: a PipelineRun has been schedule to run
+- **PipelineRun Started**: a PipelineRun has started and it is running
+- **PipelineRun Finished**: a PipelineRun has finished it execution, the event will contain the finished status, success, error or failure
+
+Each pipeline is defined as a set of Tasks to be performed in sequence, hence tracking this sequence might be important for some cases. A TaskRun is an instance of the Task defined inside the pipeline, as you can expect multiple execution of the pipelines (each a PipelineRun) you can also expect multiple execution of the Tasks, for that reason we use TaskRun to refer to one of these instances.
+
+- **TaskRun Started**: a TaskRun inside a PipelineRun has started.
+- **TaskRun Finished**: a TaskRun inside a PipelineRun has finished.
+
+Pipeline Events MUST include the following attributes:
+
+- **Event Type**: the type is restricted to include `cd.**` prefix. For example `cd.pipelinerun.queued` or `cd.tests.started`
+- **PipelineRun Id**: unique identifier for a pipeline execution
+- **Pipeline Name**: unique identifier for the pipeline, not for the instance. A pipeline can have multiple instances/runs.
+- **PipelineRun Status**: current status of the PipelineRun at the time when the event was emitted. If the pipeline is finished, this attribute should reflect if it finished successfully or if there was an error on the execution. Possible statuses: [Running, Finished, Error]
+
+Optional attributes:
+
+- **PipelineRun URL**: URL to locate where  pipeline instances are running
+- **PipelineRun Errors**: error field to indicate possible compilation, test, build and package errors.

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -1,0 +1,38 @@
+# Source Code Version Control Events
+
+__Note:__ This is a work-in-progress draft version and is being worked on by members of the Events SIG. You are very welcome to join the work and the discussions!
+
+This phase includes events related to changes in Source Code repositories that are relevant from a Continuous Delivery perspective.
+
+## Repository Events
+
+These events are related to Source Code repositories
+
+- **Repository Created Event**: a new Source Code Repository was created to host source code for a project
+- **Repository Modified Event**: a Source Code Repository modified some of its attributes, like location, or owner
+- **Repository Deleted Event**: a Source Code Repository was deleted and it is not longer available
+- **Branch Created Event**: a Branch inside the Repository was created
+- **Branch Deleted Event**: a Branch inside the Repository was deleted
+
+Repository Events MUST include the following attributes:
+
+- **Event Type**: the type is restricted to include `cd.**` prefix. For example `cd.repository.created` or `cd.repository.changeapproved`
+- **Repository URL**: indicates the location of the source code repository for API operations, this URL needs to include the protocol used to connect to the repository. For example `git://` , `ssh://`, `https://`
+- **Repository Name**: friendly name to list this repository to users
+
+Optional attributes:
+
+- **Repository Owner**: indicates who is the owner of the repository, usually a `user` or an `organization`
+- **Repository View URL**: URL to access the repository from a user web browser
+
+From each repository you can emit events related with proposed source code changes. Each change can include a single or multiple commits that can also be tracked.
+
+- **Change Created Event**: a source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit
+- **Change Reviewed Event**:  someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.
+- **Change Merged Event**: the change is merged to the target branch where it was submitted.
+- **Change Abandoned Event**: a tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
+- **Change Updated**: the Change has been updated, for example a new commit is added or removed from an existing Change
+
+Optional attributes for **Change** Events:
+
+- (TBD)

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,28 @@
+# Continuous Delivery Events Vocabulary
+
+__Note:__ This is a work-in-progress draft version and is being worked on by members of the Events SIG. You are very welcome to join the work and the discussions!
+
+This document intends to describe a set of events related to different phases of a Continuous Delivery process.
+These events are categorized by meaning, and the phase where they are intended to be used.
+These events are agnostic from any specific tool and are designed to fit a wide range of scenarios.
+
+The phases covered by this proposal are:
+
+- **[Core Events](core.md)**: includes core events related to core activities and orchestration that needs to exist to be able to deterministically and continously being able to delivery software to users.
+- **[Source Code Version Control Events](source-code-version-control.md)**: Events emitted by changes in source code or by the creation, modification or deletion of new repositories that hold source code.
+- **[Continuous Integration Pipelines Events](continuous-integration-pipeline-events.md)**: includes events related to building, testings, packaging and releasing software artifacts, usually binaries.
+- **[Continuous Deployment Pipelines Events](continuous-deployment-pipeline-events.md)**: include events related with environments where the artifacts produced by the integration pipelines actually run. These are usually services running in a specific environment (dev, QA, production), or embedded software running in a specific hardware.
+
+These phases can also be considered as different profiles of the vocabulary that can be adopted independently.
+Also notice that we currently use the term 'pipeline' to denote a pipelines, workflows and related concepts. We also use the term 'task' to denote a job/stage/step.
+
+## Required Metadata for CD Events
+
+The following attributes are REQUIRED to be present in all the Events defined in this vocabulary:
+
+- **Event ID**: defines a unique identifier for the event
+- **Event Type**: defines a textual description of the event type, only event types described in this document are supported. All event types should be prefixed with `cd.`
+- **Event Source**: defines the context in which an event happened
+- **Event Timestamp**: defines the time when the event was produced
+
+The following sections list the events in different phases, allowing adopters to choose the events that they are more interested in.


### PR DESCRIPTION
Import the draft spec as-is from github.com/cdfoundation/sig-events,
except for minor lint and spelling fixes.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>