### PR TITLE
Placeholder for binding and primer docs

### DIFF
--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -1,0 +1,12 @@
+# CloudEvents Binding for CDEvents - Draft
+
+## Abstract
+
+The CloudEvents Binding for CDEvents defines how CDEvents are mapped to CloudEvents headers and body.
+
+## Table Of Contents
+
+<!-- toc -->
+<!-- /toc -->
+
+TBD

--- a/primer.md
+++ b/primer.md
@@ -1,0 +1,18 @@
+# CDEvents Primer - Draft
+
+## Abstract
+
+This non-normative document provides an overview of the CDEvents specification. It is meant to complement the CDEvents specification to provide additional background and insight into the history and design decisions made during the development of the specification. This allows the specification itself to focus on the normative technical details.
+
+## Table of Contents
+
+<!-- toc -->
+<!-- /toc -->
+
+## History
+
+TBD
+
+## Acknowledgments
+
+The initial structure of the CDEvents specification format was based on the specification of the [CloudEvents](https://github.com/cloudevents/spec) project.


### PR DESCRIPTION
Add a CloudEvents binding document.
The CloudEvents Binding for CDEvents defines how
CDEvents are mapped to CloudEvents headers and body.

Add a primer document.
The primer document gives an overview of the CDEvents
spec, it's architecture, goals and design decisions.

Both documents are only stubs for now.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>