### PR TITLE
Add a tool to manage the TOC of various docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Spec CI
+name: CDEvents
 
 # Controls when the workflow will run
 on:

--- a/tools/.notableofcontents
+++ b/tools/.notableofcontents
@@ -1,0 +1,2 @@
+./README.md
+./code-of-conduct.md

--- a/tools/update-toc.sh
+++ b/tools/update-toc.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+# Copyright 2020 The Tekton Authors.
+# Copyright 2021 The CDEvents Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TOOL_VERSION=ee652eb78c047a7b6c7417d9324a97bb05689563
+
+# cd to the root path
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# perform go get in a temp dir as we are not tracking this version in a go module
+# if we do the go get in the repo, it will create / update a go.mod and go.sum
+cd "${TMP_DIR}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/tallclair/mdtoc@${TOOL_VERSION}"
+export PATH="${TMP_DIR}:${PATH}"
+cd "${ROOT}"
+
+# Update tables of contents if necessary.
+find . -name '*.md' | grep -Fxvf tools/.notableofcontents | xargs mdtoc --inplace


### PR DESCRIPTION
Add a tool to generate and manage the TOC of various docs.
We might want to add a CI job that checks that the TOC is
up to date once we start adding specs.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>