### PR TITLE
Explain relations to CloudEvents

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -8,12 +8,32 @@ This non-normative document provides an overview of the CDEvents specification. 
 
 <!-- toc -->
 - [History](#history)
+- [Relations to CloudEvents](#relations-to-cloudevents)
 - [Acknowledgments](#acknowledgments)
 <!-- /toc -->
 
 ## History
 
 TBD
+
+## Relations to CloudEvents
+
+CDEvents defines a specification  that provides a set of JSON object schemas
+(one for each event type, covering mandatory and optional attributes etc.)
+
+When used with CloudEvents, CDEvents passes the JSON schema  via the
+[`dataschema`](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#dataschema)
+attribute and provide the corresponding JSON object through the
+[`data`](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#event-data)
+attribute.
+
+CDEvents aims to use existing CloudEvents extension attributes (e.g.
+`partitionkey` from the
+[Partitioning](https://github.com/cloudevents/spec/blob/v1.0.1/extensions/partitioning.md)
+extension) before defining its own extensions. When no appropriate extension
+attributes exists, CDEvents aims to make an official CloudEvents extension for
+the CloudEvents specification and listed with other [documented
+extensions](https://github.com/cloudevents/spec/blob/v1.0.1/documented-extensions.md).
 
 ## Acknowledgments
 

--- a/primer.md
+++ b/primer.md
@@ -18,8 +18,9 @@ TBD
 
 ## Relations to CloudEvents
 
-CDEvents defines a specification  that provides a set of JSON object schemas
-(one for each event type, covering mandatory and optional attributes etc.)
+CDEvents defines a [specification](./cloudevents-binding.md) that provides a set
+of JSON object schemas (one for each event type, covering mandatory and optional
+attributes etc.)
 
 When used with CloudEvents, CDEvents passes the JSON schema  via the
 [`dataschema`](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#dataschema)


### PR DESCRIPTION
This amendment to the primer aims to explain the relations between CDEvents and CloudEvents. Reworded version of  [SIG Events meeting note from 19th of October 2021](https://hackmd.io/2FRGlw9fTMmKN1OQUVvguA#Meeting-19th-October).

Signed-off-by: Mattias Linnér <mattias.linner@ericsson.com>