### PR TITLE
Use dev.cdevents as root for event types

### DIFF
--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -26,7 +26,7 @@ The term Environment represent any platform which has all the means to run a Ser
 
 Continuous Deployment Events MUST include the following attributes:
 
-- __Event Type__: the type is restricted to include `cd.__` prefix. For example `cd.service.upgraded` or `cd.environment.created`
+- __Event Type__: the type is restricted to include `dev.cdevents.__` prefix. For example `dev.cdevents.service.upgraded` or `dev.cdevents.environment.created`
 - __Environment ID__: unique identifier for the Environment
 
 Optional attributes:

--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -33,7 +33,7 @@ Finally, events needs to be generated for the output of the pipeline such as the
 
 CI Events MUST include the following attributes:
 
-- __Event Type__: the type is restricted to include `cd.__` prefix. For example `cd.build.queued` or `cd.artifact.packaged`
+- __Event Type__: the type is restricted to include `dev.cdevents.__` prefix. For example `dev.cdevents.build.queued` or `dev.cdevents.artifact.packaged`
 
 Optional attributes:
 

--- a/core.md
+++ b/core.md
@@ -29,7 +29,7 @@ Each pipeline is defined as a set of Tasks to be performed in sequence, hence tr
 
 Pipeline Events MUST include the following attributes:
 
-- __Event Type__: the type is restricted to include `cd.__` prefix. For example `cd.pipelinerun.queued` or `cd.tests.started`
+- __Event Type__: the type is restricted to include `dev.cdevents.__` prefix. For example `dev.cdevents.pipelinerun.queued` or `dev.cdevents.tests.started`
 - __PipelineRun Id__: unique identifier for a pipeline execution
 - __Pipeline Name__: unique identifier for the pipeline, not for the instance. A pipeline can have multiple instances/runs.
 - __PipelineRun Status__: current status of the PipelineRun at the time when the event was emitted. If the pipeline is finished, this attribute should reflect if it finished successfully or if there was an error on the execution. Possible statuses: [Running, Finished, Error]

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -24,7 +24,7 @@ These events are related to Source Code repositories
 
 Repository Events MUST include the following attributes:
 
-- __Event Type__: the type is restricted to include `cd.__` prefix. For example `cd.repository.created` or `cd.repository.changeapproved`
+- __Event Type__: the type is restricted to include `dev.cdevents.__` prefix. For example `dev.cdevents.repository.created` or `dev.cdevents.repository.changeapproved`
 - __Repository URL__: indicates the location of the source code repository for API operations, this URL needs to include the protocol used to connect to the repository. For example `git://` , `ssh://`, `https://`
 - __Repository Name__: friendly name to list this repository to users
 

--- a/spec.md
+++ b/spec.md
@@ -29,7 +29,7 @@ Also notice that we currently use the term 'pipeline' to denote a pipelines, wor
 The following attributes are REQUIRED to be present in all the Events defined in this vocabulary:
 
 - __Event ID__: defines a unique identifier for the event
-- __Event Type__: defines a textual description of the event type, only event types described in this document are supported. All event types should be prefixed with `cd.`
+- __Event Type__: defines a textual description of the event type, only event types described in this document are supported. All event types should be prefixed with `dev.cdevents.`
 - __Event Source__: defines the context in which an event happened
 - __Event Timestamp__: defines the time when the event was produced
 


### PR DESCRIPTION
According to the CloudEvents spec, https://github.com/cloudevents/spec/blob/v1.0.1/spec.md
the event type SHOULD be prefixed with a reverse-DNS name.
The prefix domain dictates the organisation which defines
the semantics of the event type.

Since CDEvents owns the `cdevents.dev` domain, and has a website
hosted on that domain, we should use that domain in the event
types as well.

Related to #21 

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>