### PR TITLE
Add syntax details for attributes in CDEvents

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -106,7 +106,7 @@ this vocabulary:
   - MUST be a non-empty string
   - MUST be unique within the scope of the producer
 - Examples:
-  - An [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
+  - A [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random))
 
 #### type
 

--- a/spec.md
+++ b/spec.md
@@ -122,7 +122,7 @@ this vocabulary:
 - Examples:
   - dev.cdevents.taskrun.started
   - dev.cdevents.environment.created
-  - dev.cdevents.<subject>.<predicate>
+  - dev.cdevents.\<subject\>.\<predicate\>
 
 #### source
 

--- a/spec.md
+++ b/spec.md
@@ -96,7 +96,7 @@ this vocabulary:
 
 - Type: [`String`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system)
 - Description: Identifier for an event.
-  `Source`. Subsequent delivery attempts of the same event MAY share the same
+  Subsequent delivery attempts of the same event MAY share the same
   `id`. This attribute matches the syntax and semantics of the
   [`id`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)
   attribute of CloudEvents.

--- a/spec.md
+++ b/spec.md
@@ -97,14 +97,14 @@ this vocabulary:
 - Type: [`String`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system)
 - Description: Identifier for an event.
   Subsequent delivery attempts of the same event MAY share the same
-  `id`. This attribute matches the syntax and semantics of the
+  [`id`](#id). This attribute matches the syntax and semantics of the
   [`id`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)
   attribute of CloudEvents.
 
 - Constraints:
   - REQUIRED
   - MUST be a non-empty string
-  - MUST be unique within the given `source` (in the scope of the producer)
+  - MUST be unique within the given [`source`](#source) (in the scope of the producer)
 - Examples:
   - A [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random))
 
@@ -120,15 +120,16 @@ this vocabulary:
   - REQUIRED
   - MUST be defined in the [vocabulary](#vocabulary)
 - Examples:
-  - dev.cdevents.taskrun.started
-  - dev.cdevents.environment.created
-  - dev.cdevents.\<subject\>.\<predicate\>
+  - `dev.cdevents.taskrun.started`
+  - `dev.cdevents.environment.created`
+  - `dev.cdevents.<subject>.<predicate>`
 
 #### source
 
 - Type: [`URI-Reference`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system)
 - Description: defines the context in which an event happened. The main purpose
-  of the source is to provide global uniqueness for `source` + `id`.
+  of the source is to provide global uniqueness for [`source`](#source) +
+  [`id`](#id).
 
   The source MAY identify a single producer or a group of producer that belong
   to the same application.
@@ -167,7 +168,8 @@ this vocabulary:
 
   In case the transport layer should require a re-transmission of the event,
   the timestamp SHOULD NOT be updated, i.e. it should be the same for the same
-  `source` + `id` combination.
+  [`source`](#source) + [`id`](#id) combination.
+
 - Constraints:
   - REQUIRED
   - MUST adhere to the format specified in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339)
@@ -187,12 +189,12 @@ this vocabulary:
 #### subject
 
 - Type: `Object`
-- Description: This provides all the relevant details of the `subject`. The
-  format of the subject depends on the event `type`.
+- Description: This provides all the relevant details of the [`subject`](#subject). The
+  format of the [`subject`](#subject-1) depends on the event [`type`](#type).
 
   The attributes available for each subject are defined in the
   [`vocabulary`](#vocabulary). The REQUIRED and OPTIONAL attributes depend on
-  the event `type` and are specified in the [`vocabulary`](#vocabulary).
+  the event [`type`](#type) and are specified in the [`vocabulary`](#vocabulary).
 
 - Constraints:
   - REQUIRED

--- a/spec.md
+++ b/spec.md
@@ -97,7 +97,7 @@ this vocabulary:
 - Type: [`String`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system)
 - Description: Identifier for an event. The `ID` MUST be unique within the given
   `Source`. Subsequent delivery attempts of the same event MAY share the same
-  `ID`. This fields matches the syntax and semantics of the
+  `id`. This attribute matches the syntax and semantics of the
   [`id`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)
   attribute of CloudEvents.
 

--- a/spec.md
+++ b/spec.md
@@ -90,7 +90,7 @@ predicate are defined in the [vocabulary](#vocabulary).
 ### REQUIRED Event Attributes
 
 The following attributes are REQUIRED to be present in all the Events defined in
-this vocabulary:
+the [vocabulary](#vocabulary):
 
 #### id
 
@@ -193,12 +193,12 @@ this vocabulary:
   format of the [`subject`](#subject-1) depends on the event [`type`](#type).
 
   The attributes available for each subject are defined in the
-  [`vocabulary`](#vocabulary). The REQUIRED and OPTIONAL attributes depend on
-  the event [`type`](#type) and are specified in the [`vocabulary`](#vocabulary).
+  [vocabulary](#vocabulary). The REQUIRED and OPTIONAL attributes depend on
+  the event [`type`](#type) and are specified in the [vocabulary](#vocabulary).
 
 - Constraints:
   - REQUIRED
-  - If present, MUST comply with the spec from the [`vocabulary`](#vocabulary).
+  - If present, MUST comply with the spec from the [vocabulary](#vocabulary).
 
 - Example:
   - Considering the event type `dev.cdevents.taskrun.started`, an example of

--- a/spec.md
+++ b/spec.md
@@ -104,7 +104,7 @@ this vocabulary:
 - Constraints:
   - REQUIRED
   - MUST be a non-empty string
-  - MUST be unique within the scope of the producer
+  - MUST be unique within the given `source` (in the scope of the producer)
 - Examples:
   - A [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random))
 

--- a/spec.md
+++ b/spec.md
@@ -95,7 +95,7 @@ this vocabulary:
 #### id
 
 - Type: [`String`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system)
-- Description: Identifier for an event. The `ID` MUST be unique within the given
+- Description: Identifier for an event.
   `Source`. Subsequent delivery attempts of the same event MAY share the same
   `id`. This attribute matches the syntax and semantics of the
   [`id`](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)


### PR DESCRIPTION
Expand the definition of mandatory attributes by adding syntax
details and examples.

Introduce the "version" as a mandatory attribute.
Add the subject as an optional attribute as discussed in the WG.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>