### PR TITLE
Add jsonschema for the events

### DIFF
--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/artifact-packaged-event",
+  "$id": "https://cdevents.dev/draft/schema/artifact-packaged-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/artifact-packaged-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/artifact-published-event",
+  "$id": "https://cdevents.dev/draft/schema/artifact-published-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/artifact-published-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/branch-created-event",
+  "$id": "https://cdevents.dev/draft/schema/branch-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/branch-created-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/branch-deleted-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/branch-deleted-event",
+  "$id": "https://cdevents.dev/draft/schema/branch-deleted-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-finished-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/build-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -68,6 +68,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-queued-event",
+  "$id": "https://cdevents.dev/draft/schema/build-queued-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-queued-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-started-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/build-started-event",
+  "$id": "https://cdevents.dev/draft/schema/build-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-abandoned-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-abandoned-event",
+  "$id": "https://cdevents.dev/draft/schema/change-abandoned-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-created-event",
+  "$id": "https://cdevents.dev/draft/schema/change-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-created-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-merged-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-merged-event",
+  "$id": "https://cdevents.dev/draft/schema/change-merged-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-reviewed-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-reviewed-event",
+  "$id": "https://cdevents.dev/draft/schema/change-reviewed-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-updated-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/change-updated-event",
+  "$id": "https://cdevents.dev/draft/schema/change-updated-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-created-event",
+  "$id": "https://cdevents.dev/draft/schema/environment-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -71,6 +71,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-created-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-deleted-event",
+  "$id": "https://cdevents.dev/draft/schema/environment-deleted-event",
   "properties": {
     "context": {
       "properties": {
@@ -68,6 +68,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-deleted-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-modified-event",
+  "$id": "https://cdevents.dev/draft/schema/environment-modified-event",
   "properties": {
     "context": {
       "properties": {
@@ -71,6 +71,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/environment-modified-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-finished-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "pipelineName": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "outcome": {
+              "type": "string"
+            },
+            "errors": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/pipeline-run-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-queued-event",
+  "$id": "https://cdevents.dev/draft/schema/pipeline-run-queued-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-queued-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "pipelineName": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "outcome": {
+              "type": "string"
+            },
+            "errors": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-started-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "pipelineName": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "pipelineName",
+            "url"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/pipeline-run-started-event",
+  "$id": "https://cdevents.dev/draft/schema/pipeline-run-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -75,6 +75,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-created-event",
+  "$id": "https://cdevents.dev/draft/schema/repository-created-event",
   "properties": {
     "context": {
       "properties": {
@@ -83,6 +83,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-created-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "owner": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "minLength": 1
+            },
+            "viewUrl": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "name",
+            "url"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-deleted-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "viewUrl": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-deleted-event",
+  "$id": "https://cdevents.dev/draft/schema/repository-deleted-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-modified-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "viewUrl": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/repository-modified-event",
+  "$id": "https://cdevents.dev/draft/schema/repository-modified-event",
   "properties": {
     "context": {
       "properties": {
@@ -77,6 +77,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-deployed-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-deployed-event",
+  "$id": "https://cdevents.dev/draft/schema/service-deployed-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-published-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-published-event",
+  "$id": "https://cdevents.dev/draft/schema/service-published-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-removed-event",
+  "$id": "https://cdevents.dev/draft/schema/service-removed-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-removed-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-rolledback-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-rolledback-event",
+  "$id": "https://cdevents.dev/draft/schema/service-rolledback-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-upgraded-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/service-upgraded-event",
+  "$id": "https://cdevents.dev/draft/schema/service-upgraded-event",
   "properties": {
     "context": {
       "properties": {
@@ -81,6 +81,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/task-run-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/task-run-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -93,6 +93,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/task-run-finished-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "taskName": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "pipelineRun": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "outcome": {
+              "type": "string"
+            },
+            "errors": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/task-run-started-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {
+            "taskName": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "pipelineRun": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/task-run-started-event",
+  "$id": "https://cdevents.dev/draft/schema/task-run-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -87,6 +87,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/test-case-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-finished-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-queued-event",
+  "$id": "https://cdevents.dev/draft/schema/test-case-queued-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-queued-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-started-event",
+  "$id": "https://cdevents.dev/draft/schema/test-case-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-case-started-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-suite-finished-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-suite-finished-event",
+  "$id": "https://cdevents.dev/draft/schema/test-suite-finished-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-suite-started-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": [
+            "draft"
+          ],
+          "default": "draft"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content": {
+          "properties": {},
+          "additionalProperties": false,
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "content"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/cdevents/sdk-go/pkg/api/test-suite-started-event",
+  "$id": "https://cdevents.dev/draft/schema/test-suite-started-event",
   "properties": {
     "context": {
       "properties": {
@@ -64,6 +64,13 @@
         "type",
         "content"
       ]
+    },
+    "customData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "customDataContentType": {
+      "type": "string"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Add initial jsonschemas for all of the events.

These json schemas are automatically generated through the
go types defined in the new cdevents/go-sdk, using the
library github.com/invopop/jsonschema, see
https://github.com/cdevents/sdk-go/pull/6 for details.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>