### PR TITLE
Add versioning details to spec and primer

### DIFF
--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -94,7 +94,7 @@ Full example of a CDEvents transported through a CloudEvent in HTTP *binary* mod
 POST /sink HTTP/1.1
 Host: cdevents.example.com
 ce-specversion: 1.0
-ce-type: dev.cdevents.taskrun.started
+ce-type: dev.cdevents.taskrun.started.0.1-draft
 ce-time: 2018-04-05T17:31:00Z
 ce-id: A234-1234-1234
 ce-source: /staging/tekton/

--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -104,7 +104,7 @@ Content-Length: nnnn
 
 {
    "context": {
-      "version" : "draft",
+      "version" : "0.1.0-draft",
       "id" : "A234-1234-1234",
       "source" : "/staging/tekton/",
       "type" : "dev.cdevents.taskrun.started",

--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -48,7 +48,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 This event represents an environment that has been created. Such an environment can be used to deploy services in.
 
-- Event Type: __`dev.cdevents.environment.created`__
+- Event Type: __`dev.cdevents.environment.created.0.1-draft`__
 - Predicate: created
 - Subject: [`environment`](#environment)
 
@@ -63,7 +63,7 @@ This event represents an environment that has been created. Such an environment 
 
 This event represents an environment that has been modified.
 
-- Event Type: __`dev.cdevents.environment.modified`__
+- Event Type: __`dev.cdevents.environment.modified.0.1-draft`__
 - Predicate: modified
 - Subject: [`environment`](#environment)
 
@@ -78,7 +78,7 @@ This event represents an environment that has been modified.
 
 This event represents an environment that has been deleted.```
 
-- Event Type: __`dev.cdevents.environment.deleted`__
+- Event Type: __`dev.cdevents.environment.deleted.0.1-draft`__
 - Predicate: deleted
 - Subject: [`environment`](#environment)
 
@@ -92,7 +92,7 @@ This event represents an environment that has been deleted.```
 
 This event represents a new instance of a service that has been deployed
 
-- Event Type: __`dev.cdevents.service.deployed`__
+- Event Type: __`dev.cdevents.service.deployed.0.1-draft`__
 - Predicate: deployed
 - Subject: [`service`](#service)
 
@@ -105,7 +105,7 @@ This event represents a new instance of a service that has been deployed
 
 This event represents an existing instance of a service that has been upgraded to a new version
 
-- Event Type: __`dev.cdevents.service.upgraded`__
+- Event Type: __`dev.cdevents.service.upgraded.0.1-draft`__
 - Predicate: upgraded
 - Subject: [`service`](#service)
 
@@ -118,7 +118,7 @@ This event represents an existing instance of a service that has been upgraded t
 
 This event represents an existing instance of a service that has been rolled back to a previous version
 
-- Event Type: __`dev.cdevents.service.rolledback`__
+- Event Type: __`dev.cdevents.service.rolledback.0.1-draft`__
 - Predicate: rolledback
 - Subject: [`service`](#service)
 
@@ -131,7 +131,7 @@ This event represents an existing instance of a service that has been rolled bac
 
 This event represents the removal of a previously deployed service instance and is thus not longer present in the specified environment
 
-- Event Type: __`dev.cdevents.service.removed`__
+- Event Type: __`dev.cdevents.service.removed.0.1-draft`__
 - Predicate: removed
 - Subject: [`service`](#service)
 
@@ -144,7 +144,7 @@ This event represents the removal of a previously deployed service instance and 
 
 This event represents an existing instance of a service that has an accessible URL for users to interact with it. This event can be used to let other tools know that the service is ready and also available for consumption.
 
-- Event Type: __`dev.cdevents.service.published`__
+- Event Type: __`dev.cdevents.service.published.0.1-draft`__
 - Predicate: published
 - Subject: [`service`](#service)
 

--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -72,7 +72,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 This event represents a Build task that has been queued; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.queued.0.1-draft`__
+- Event Type: __`dev.cdevents.build.queued.0.1.0-draft`__
 - Predicate: queued
 - Subject: [`build`](#build)
 
@@ -87,7 +87,7 @@ This event represents a Build task that has been queued; this build process usua
 
 This event represents a Build task that has been started; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.started.0.1-draft`__
+- Event Type: __`dev.cdevents.build.started.0.1.0-draft`__
 - Predicate: started
 - Subject: [`build`](#build)
 
@@ -102,7 +102,7 @@ This event represents a Build task that has been started; this build process usu
 
 This event represents a Build task that has finished. This event will eventually contain the finished status, success, error or failure
 
-- Event Type: __`dev.cdevents.build.finished.0.1-draft`__
+- Event Type: __`dev.cdevents.build.finished.0.1.0-draft`__
 - Predicate: finished
 - Subject: [`build`](#build)
 
@@ -118,7 +118,7 @@ This event represents a Build task that has finished. This event will eventually
 
 This event represents a Test task that has been queued, and it is waiting to be started.
 
-- Event Type: __`dev.cdevents.testcase.queued.0.1-draft`__
+- Event Type: __`dev.cdevents.testcase.queued.0.1.0-draft`__
 - Predicate: queued
 - Subject: [`testCase`](#testcase)
 
@@ -133,7 +133,7 @@ This event represents a Test task that has been queued, and it is waiting to be 
 
 This event represents a Test task that has started.
 
-- Event Type: __`dev.cdevents.testcase.started.0.1-draft`__
+- Event Type: __`dev.cdevents.testcase.started.0.1.0-draft`__
 - Predicate: started
 - Subject: [`testCase`](#testcase)
 
@@ -148,7 +148,7 @@ This event represents a Test task that has started.
 
 This event represents a Test task that has finished. This event will eventually contain the finished status: success, error or failure.
 
-- Event Type: __`dev.cdevents.testcase.finished.0.1-draft`__
+- Event Type: __`dev.cdevents.testcase.finished.0.1.0-draft`__
 - Predicate: finished
 - Subject: [`testCase`](#testcase)
 
@@ -163,7 +163,7 @@ This event represents a Test task that has finished. This event will eventually 
 
 This event represents a Test suite that has been started.
 
-- Event Type: __`dev.cdevents.testsuite.started.0.1-draft`__
+- Event Type: __`dev.cdevents.testsuite.started.0.1.0-draft`__
 - Predicate: started
 - Subject: [`testSuite`](#testsuite)
 
@@ -178,7 +178,7 @@ This event represents a Test suite that has been started.
 
 This event represents a Test suite that has has finished, the event will contain the finished status: success, error or failure.
 
-- Event Type: __`dev.cdevents.testsuite.finished.0.1-draft`__
+- Event Type: __`dev.cdevents.testsuite.finished.0.1.0-draft`__
 - Predicate: finished
 - Subject: [`testSuite`](#testsuite)
 
@@ -193,7 +193,7 @@ This event represents a Test suite that has has finished, the event will contain
 
 The event represents an artifact that has been packaged for distribution; this artifact is now versioned with a fixed version.
 
-- Event Type: __`dev.cdevents.artifact.packaged.0.1-draft`__
+- Event Type: __`dev.cdevents.artifact.packaged.0.1.0-draft`__
 - Predicate: packaged
 - Subject: [`artifact`](#artifact)
 
@@ -206,7 +206,7 @@ The event represents an artifact that has been packaged for distribution; this a
 
 The event represents an artifact that has been published and it can be advertised for others to use.
 
-- Event Type: __`dev.cdevents.artifact.published.0.1-draft`__
+- Event Type: __`dev.cdevents.artifact.published.0.1.0-draft`__
 - Predicate: published
 - Subject: [`artifact`](#artifact)
 

--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -72,7 +72,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 This event represents a Build task that has been queued; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.queued`__
+- Event Type: __`dev.cdevents.build.queued.0.1-draft`__
 - Predicate: queued
 - Subject: [`build`](#build)
 
@@ -87,7 +87,7 @@ This event represents a Build task that has been queued; this build process usua
 
 This event represents a Build task that has been started; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.started`__
+- Event Type: __`dev.cdevents.build.started.0.1-draft`__
 - Predicate: started
 - Subject: [`build`](#build)
 
@@ -102,7 +102,7 @@ This event represents a Build task that has been started; this build process usu
 
 This event represents a Build task that has finished. This event will eventually contain the finished status, success, error or failure
 
-- Event Type: __`dev.cdevents.build.finished`__
+- Event Type: __`dev.cdevents.build.finished.0.1-draft`__
 - Predicate: finished
 - Subject: [`build`](#build)
 
@@ -118,7 +118,7 @@ This event represents a Build task that has finished. This event will eventually
 
 This event represents a Test task that has been queued, and it is waiting to be started.
 
-- Event Type: __`dev.cdevents.testcase.queued`__
+- Event Type: __`dev.cdevents.testcase.queued.0.1-draft`__
 - Predicate: queued
 - Subject: [`testCase`](#testcase)
 
@@ -133,7 +133,7 @@ This event represents a Test task that has been queued, and it is waiting to be 
 
 This event represents a Test task that has started.
 
-- Event Type: __`dev.cdevents.testcase.started`__
+- Event Type: __`dev.cdevents.testcase.started.0.1-draft`__
 - Predicate: started
 - Subject: [`testCase`](#testcase)
 
@@ -148,7 +148,7 @@ This event represents a Test task that has started.
 
 This event represents a Test task that has finished. This event will eventually contain the finished status: success, error or failure.
 
-- Event Type: __`dev.cdevents.testcase.finished`__
+- Event Type: __`dev.cdevents.testcase.finished.0.1-draft`__
 - Predicate: finished
 - Subject: [`testCase`](#testcase)
 
@@ -163,7 +163,7 @@ This event represents a Test task that has finished. This event will eventually 
 
 This event represents a Test suite that has been started.
 
-- Event Type: __`dev.cdevents.testsuite.started`__
+- Event Type: __`dev.cdevents.testsuite.started.0.1-draft`__
 - Predicate: started
 - Subject: [`testSuite`](#testsuite)
 
@@ -178,7 +178,7 @@ This event represents a Test suite that has been started.
 
 This event represents a Test suite that has has finished, the event will contain the finished status: success, error or failure.
 
-- Event Type: __`dev.cdevents.testsuite.finished`__
+- Event Type: __`dev.cdevents.testsuite.finished.0.1-draft`__
 - Predicate: finished
 - Subject: [`testSuite`](#testsuite)
 
@@ -193,7 +193,7 @@ This event represents a Test suite that has has finished, the event will contain
 
 The event represents an artifact that has been packaged for distribution; this artifact is now versioned with a fixed version.
 
-- Event Type: __`dev.cdevents.artifact.packaged`__
+- Event Type: __`dev.cdevents.artifact.packaged.0.1-draft`__
 - Predicate: packaged
 - Subject: [`artifact`](#artifact)
 
@@ -206,7 +206,7 @@ The event represents an artifact that has been packaged for distribution; this a
 
 The event represents an artifact that has been published and it can be advertised for others to use.
 
-- Event Type: __`dev.cdevents.artifact.published`__
+- Event Type: __`dev.cdevents.artifact.published.0.1-draft`__
 - Predicate: published
 - Subject: [`artifact`](#artifact)
 

--- a/core.md
+++ b/core.md
@@ -66,7 +66,7 @@ Due the dynamic nature of Pipelines, most of actual work needs to be queued to
 happen in a distributed way, hence queued events are added. Adopters can choose
 to ignore these events if they don't apply to their use cases.
 
-- Event Type: __`dev.cdevents.pipelinerun.queued`__
+- Event Type: __`dev.cdevents.pipelinerun.queued.0.1-draft`__
 - Predicate: queued
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -81,7 +81,7 @@ to ignore these events if they don't apply to their use cases.
 
 A pipelineRun has started and it is running.
 
-- Event Type: __`dev.cdevents.pipelinerun.started`__
+- Event Type: __`dev.cdevents.pipelinerun.started.0.1-draft`__
 - Predicate: started
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -96,7 +96,7 @@ A pipelineRun has started and it is running.
 
 A pipelineRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.pipelinerun.finished`__
+- Event Type: __`dev.cdevents.pipelinerun.finished.0.1-draft`__
 - Predicate: finished
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -113,7 +113,7 @@ A pipelineRun has finished, successfully or not.
 
 A taskRun has started and it is running.
 
-- Event Type: __`dev.cdevents.taskrun.started`__
+- Event Type: __`dev.cdevents.taskrun.started.0.1-draft`__
 - Predicate: started
 - Subject: [`taskRun`](#taskrun)
 
@@ -129,7 +129,7 @@ A taskRun has started and it is running.
 
 A taskRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.taskrun.finished`__
+- Event Type: __`dev.cdevents.taskrun.finished.0.1-draft`__
 - Predicate: finished
 - Subject: [`taskRun`](#taskrun)
 

--- a/core.md
+++ b/core.md
@@ -66,7 +66,7 @@ Due the dynamic nature of Pipelines, most of actual work needs to be queued to
 happen in a distributed way, hence queued events are added. Adopters can choose
 to ignore these events if they don't apply to their use cases.
 
-- Event Type: __`dev.cdevents.pipelinerun.queued.0.1-draft`__
+- Event Type: __`dev.cdevents.pipelinerun.queued.0.1.0-draft`__
 - Predicate: queued
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -81,7 +81,7 @@ to ignore these events if they don't apply to their use cases.
 
 A pipelineRun has started and it is running.
 
-- Event Type: __`dev.cdevents.pipelinerun.started.0.1-draft`__
+- Event Type: __`dev.cdevents.pipelinerun.started.0.1.0-draft`__
 - Predicate: started
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -96,7 +96,7 @@ A pipelineRun has started and it is running.
 
 A pipelineRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.pipelinerun.finished.0.1-draft`__
+- Event Type: __`dev.cdevents.pipelinerun.finished.0.1.0-draft`__
 - Predicate: finished
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -113,7 +113,7 @@ A pipelineRun has finished, successfully or not.
 
 A taskRun has started and it is running.
 
-- Event Type: __`dev.cdevents.taskrun.started.0.1-draft`__
+- Event Type: __`dev.cdevents.taskrun.started.0.1.0-draft`__
 - Predicate: started
 - Subject: [`taskRun`](#taskrun)
 
@@ -129,7 +129,7 @@ A taskRun has started and it is running.
 
 A taskRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.taskrun.finished.0.1-draft`__
+- Event Type: __`dev.cdevents.taskrun.finished.0.1.0-draft`__
 - Predicate: finished
 - Subject: [`taskRun`](#taskrun)
 

--- a/primer.md
+++ b/primer.md
@@ -98,6 +98,65 @@ attributes exists, CDEvents aims to make an official CloudEvents extension for
 the CloudEvents specification and listed with other [documented
 extensions](https://github.com/cloudevents/spec/blob/v1.0.1/documented-extensions.md).
 
+## Versioning
+
+The CDEvents specification and events are versioned independently, both following the
+principle of semantic versioning.
+
+### Versioning of CDEvents
+
+Individual CDEvents are versioned using semantic versioning, with a `major.minor`
+format of the version.
+
+- Backward compatible changes to events are identified by a change in the minor
+  version of the event, for instance 0.1 -> 0.2. This means that an unmodified
+  consumer can parse a more recent minor version of an event, as long as it ignores
+  extra fields. Fields introduced in the new minor version will be ignored, but
+  everything else will work as before.
+
+- Backward incompatible changes to events are identified by a change in the major
+  version of the event, for instance 0.3 -> 1.0. Moved or removed fields will
+  require a new major version.
+
+while the specification of an event is work in progress, its version is tagged with
+an extra `-draft` at the end.
+
+The version of an event is included in its type. This allows for easy filtering of
+events of a specific version, by looking at a single field in the context. Examples
+of full event versions are:
+
+- `dev.cdevents.build.queued.0.1-draft`
+- `dev.cdevents.environment.deleted.0.1`
+
+### Versioning of the CDEvents specification
+
+The overall CDEvents specification is versioned using semantic versioning, with a
+`major.minor.patch` format of the version. The specification version is associated
+to a git version (tag) in the `cdevents/spec` repository, in the format
+`vMajor.Minor.Patch`.
+
+- A specification that includes only cosmetic fixes is identified by a change in the
+  patch version, for instance 0.1.0 -> 0.1.1
+
+- A specification that includes only backwards compatible change is identified by
+  a change in the minor version, for instance 0.1.3 -> 0.2.0
+
+- A specification that includes at least one backward incompatible change, is
+  identified by a change in the major version, for instance 0.1.2 -> 2.0.0
+
+While a version of the specification is work in progress, its version is tagged with
+an extra `-draft` at the end, for instance 0.1.0-draft.
+
+### Development of a new version
+
+The specification on the main branch is versioned with the number of the next
+version followed by a `-draft`. If any event is modified, its version is changed
+accordingly, followed by a `-draft` as well.
+
+Once a specification is ready for release, its number if updated, the event versions
+are finalized (`-draft` is removed), schemas are updated and a git tag is created for
+this last commit.
+
 ## Acknowledgments
 
 The initial structure of the CDEvents specification format was based on the specification of the [CloudEvents](https://github.com/cloudevents/spec) project.

--- a/primer.md
+++ b/primer.md
@@ -100,52 +100,62 @@ extensions](https://github.com/cloudevents/spec/blob/v1.0.1/documented-extension
 
 ## Versioning
 
-The CDEvents specification and events are versioned independently, both following the
-principle of semantic versioning.
+The CDEvents specification and events are versioned independently, both
+following the principle of semantic versioning.
 
 ### Versioning of CDEvents
 
-Individual CDEvents are versioned using semantic versioning, with a `major.minor`
-format of the version.
+Individual CDEvents are versioned using semantic versioning, with a
+`major.minor.patch` format of the version.
 
-- Backward compatible changes to events are identified by a change in the minor
-  version of the event, for instance 0.1 -> 0.2. This means that an unmodified
-  consumer can parse a more recent minor version of an event, as long as it ignores
-  extra fields. Fields introduced in the new minor version will be ignored, but
-  everything else will work as before.
+Backward compatible changes are changes that allow existing consumers to parse
+messages with a newer version, have access to the same data as before, as long
+the extra fields are ignored. Broadening the accepted values for a property is a
+backward incompatible change, as the consumer may not be prepared to manage the
+new format of value.
 
-- Backward incompatible changes to events are identified by a change in the major
-  version of the event, for instance 0.3 -> 1.0. Moved or removed fields will
-  require a new major version.
+Note that this means that consumers SHOULD be prepared to handle (and disregard)
+unrecognized properties in higher minor versions than they are familiar with.
 
-while the specification of an event is work in progress, its version is tagged with
-an extra `-draft` at the end.
+- Major versions (e.g. 0.3.1 -> 1.0.0): backward incompatible changes to events.
+  Renamed, moved or removed fields requires a new major version.
 
-The version of an event is included in its type. This allows for easy filtering of
-events of a specific version, by looking at a single field in the context. Examples
-of full event versions are:
+- Minor versions (e.g. 0.1.2 -> 0.2.0): backward compatible changes to events
+  that involve a structural change in the schema. A new field is added, a copy
+  of an existing field is added and the old location deprecated, or a new
 
-- `dev.cdevents.build.queued.0.1-draft`
-- `dev.cdevents.environment.deleted.0.1`
+- Patch versions (e.g. 0.1.0 -> 0.1.1): backward compatible changes to events
+  that do not involve any structural change in the schema, for instance
+  narrowing the accepted values for a property
+
+While the specification of an event is work in progress, its version is tagged
+with an extra `-draft` at the end.
+
+The version of an event is included in its type. This allows for easy filtering
+of events of a specific version, by looking at a single field in the context.
+Examples of full event versions are:
+
+- `dev.cdevents.build.queued.0.1.0-draft`
+- `dev.cdevents.environment.deleted.0.1.0`
 
 ### Versioning of the CDEvents specification
 
-The overall CDEvents specification is versioned using semantic versioning, with a
-`major.minor.patch` format of the version. The specification version is associated
-to a git version (tag) in the `cdevents/spec` repository, in the format
-`vMajor.Minor.Patch`.
+The overall CDEvents specification is versioned using semantic versioning, with
+a `major.minor.patch` format of the version. The specification version is
+associated to a git version (tag) in the `cdevents/spec` repository, in the
+format `vMajor.Minor.Patch`.
 
-- A specification that includes only cosmetic fixes is identified by a change in the
-  patch version, for instance 0.1.0 -> 0.1.1
+- A specification that includes only cosmetic fixes is identified by a change in
+  the patch version, for instance 0.1.0 -> 0.1.1
 
-- A specification that includes only backwards compatible change is identified by
-  a change in the minor version, for instance 0.1.3 -> 0.2.0
+- A specification that includes only backwards compatible change is identified
+  by a change in the minor version, for instance 0.1.3 -> 0.2.0
 
 - A specification that includes at least one backward incompatible change, is
   identified by a change in the major version, for instance 0.1.2 -> 2.0.0
 
-While a version of the specification is work in progress, its version is tagged with
-an extra `-draft` at the end, for instance 0.1.0-draft.
+While a version of the specification is work in progress, its version is tagged
+with an extra `-draft` at the end, for instance 0.1.0-draft.
 
 ### Development of a new version
 

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/artifact-packaged-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/artifact-packaged-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/artifact-published-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/artifact-published-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/branch-created-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/branch-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/branch-deleted-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/branch-deleted-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/build-finished-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/build-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/build-queued-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/build-queued-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/build-started-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/build-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/change-abandoned-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/change-abandoned-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/change-created-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/change-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/change-merged-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/change-merged-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/change-reviewed-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/change-reviewed-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/change-updated-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/change-updated-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/environment-created-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/environment-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/environment-deleted-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/environment-deleted-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/environment-modified-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/environment-modified-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/pipeline-run-finished-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/pipeline-run-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/pipeline-run-queued-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/pipeline-run-queued-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/pipeline-run-started-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/pipeline-run-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/repository-created-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/repository-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/repository-deleted-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/repository-deleted-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/repository-modified-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/repository-modified-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/service-deployed-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/service-deployed-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/service-published-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/service-published-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/service-removed-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/service-removed-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/service-rolledback-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/service-rolledback-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/service-upgraded-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/service-upgraded-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/task-run-finished-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/task-run-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/task-run-started-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/task-run-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/test-case-finished-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/test-case-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/test-case-queued-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/test-case-queued-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/test-case-started-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/test-case-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/test-suite-finished-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/test-suite-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/draft/schema/test-suite-started-event",
+  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.1.0-draft/schema/test-suite-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "draft"
+            "0.1.0-draft"
           ],
-          "default": "draft"
+          "default": "0.1.0-draft"
         },
         "id": {
           "type": "string",

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -61,7 +61,7 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 
 A new Source Code Repository was created to host source code for a project.
 
-- Event Type: __`dev.cdevents.repository.created`__
+- Event Type: __`dev.cdevents.repository.created.0.1-draft`__
 - Predicate: created
 - Subject: [`repository`](#repository)
 
@@ -78,7 +78,7 @@ A new Source Code Repository was created to host source code for a project.
 
 A Source Code Repository modified some of its attributes, like location, or owner.
 
-- Event Type: __`dev.cdevents.repository.modified`__
+- Event Type: __`dev.cdevents.repository.modified.0.1-draft`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -93,7 +93,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 ### `repository deleted`
 
-- Event Type: __`dev.cdevents.repository.deleted`__
+- Event Type: __`dev.cdevents.repository.deleted.0.1-draft`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -110,7 +110,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 A branch inside the Repository was created.
 
-- Event Type: __`dev.cdevents.branch.created`__
+- Event Type: __`dev.cdevents.branch.created.0.1-draft`__
 - Predicate: created
 - Subject: [`branch`](#branch)
 
@@ -125,7 +125,7 @@ A branch inside the Repository was created.
 
 A branch inside the Repository was deleted.
 
-- Event Type: __`dev.cdevents.branch.deleted`__
+- Event Type: __`dev.cdevents.branch.deleted.0.1-draft`__
 - Predicate: deleted
 - Subject: [`branch`](#branch)
 
@@ -140,7 +140,7 @@ A branch inside the Repository was deleted.
 
 A source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit.
 
-- Event Type: __`dev.cdevents.change.created`__
+- Event Type: __`dev.cdevents.change.created.0.1-draft`__
 - Predicate: created
 - Subject: [`change`](#change)
 
@@ -155,7 +155,7 @@ A source code change was created and submitted to a repository specific branch. 
 
 Someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.
 
-- Event Type: __`dev.cdevents.change.reviewed`__
+- Event Type: __`dev.cdevents.change.reviewed.0.1-draft`__
 - Predicate: reviewed
 - Subject: [`change`](#change)
 
@@ -170,7 +170,7 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 A change is merged to the target branch where it was submitted.
 
-- Event Type: __`dev.cdevents.change.merged`__
+- Event Type: __`dev.cdevents.change.merged.0.1-draft`__
 - Predicate: merged
 - Subject: [`change`](#change)
 
@@ -185,7 +185,7 @@ A change is merged to the target branch where it was submitted.
 
 A tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
 
-- Event Type: __`dev.cdevents.change.abandoned`__
+- Event Type: __`dev.cdevents.change.abandoned.0.1-draft`__
 - Predicate: abandoned
 - Subject: [`change`](#change)
 
@@ -200,7 +200,7 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 A Change has been updated, for example a new commit is added or removed from an existing Change.
 
-- Event Type: __`dev.cdevents.change.updated`__
+- Event Type: __`dev.cdevents.change.updated.0.1-draft`__
 - Predicate: updated
 - Subject: [`change`](#change)
 

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -61,7 +61,7 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 
 A new Source Code Repository was created to host source code for a project.
 
-- Event Type: __`dev.cdevents.repository.created.0.1-draft`__
+- Event Type: __`dev.cdevents.repository.created.0.1.0-draft`__
 - Predicate: created
 - Subject: [`repository`](#repository)
 
@@ -78,7 +78,7 @@ A new Source Code Repository was created to host source code for a project.
 
 A Source Code Repository modified some of its attributes, like location, or owner.
 
-- Event Type: __`dev.cdevents.repository.modified.0.1-draft`__
+- Event Type: __`dev.cdevents.repository.modified.0.1.0-draft`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -93,7 +93,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 ### `repository deleted`
 
-- Event Type: __`dev.cdevents.repository.deleted.0.1-draft`__
+- Event Type: __`dev.cdevents.repository.deleted.0.1.0-draft`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -110,7 +110,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 A branch inside the Repository was created.
 
-- Event Type: __`dev.cdevents.branch.created.0.1-draft`__
+- Event Type: __`dev.cdevents.branch.created.0.1.0-draft`__
 - Predicate: created
 - Subject: [`branch`](#branch)
 
@@ -125,7 +125,7 @@ A branch inside the Repository was created.
 
 A branch inside the Repository was deleted.
 
-- Event Type: __`dev.cdevents.branch.deleted.0.1-draft`__
+- Event Type: __`dev.cdevents.branch.deleted.0.1.0-draft`__
 - Predicate: deleted
 - Subject: [`branch`](#branch)
 
@@ -140,7 +140,7 @@ A branch inside the Repository was deleted.
 
 A source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit.
 
-- Event Type: __`dev.cdevents.change.created.0.1-draft`__
+- Event Type: __`dev.cdevents.change.created.0.1.0-draft`__
 - Predicate: created
 - Subject: [`change`](#change)
 
@@ -155,7 +155,7 @@ A source code change was created and submitted to a repository specific branch. 
 
 Someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.
 
-- Event Type: __`dev.cdevents.change.reviewed.0.1-draft`__
+- Event Type: __`dev.cdevents.change.reviewed.0.1.0-draft`__
 - Predicate: reviewed
 - Subject: [`change`](#change)
 
@@ -170,7 +170,7 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 A change is merged to the target branch where it was submitted.
 
-- Event Type: __`dev.cdevents.change.merged.0.1-draft`__
+- Event Type: __`dev.cdevents.change.merged.0.1.0-draft`__
 - Predicate: merged
 - Subject: [`change`](#change)
 
@@ -185,7 +185,7 @@ A change is merged to the target branch where it was submitted.
 
 A tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
 
-- Event Type: __`dev.cdevents.change.abandoned.0.1-draft`__
+- Event Type: __`dev.cdevents.change.abandoned.0.1.0-draft`__
 - Predicate: abandoned
 - Subject: [`change`](#change)
 
@@ -200,7 +200,7 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 A Change has been updated, for example a new commit is added or removed from an existing Change.
 
-- Event Type: __`dev.cdevents.change.updated.0.1-draft`__
+- Event Type: __`dev.cdevents.change.updated.0.1.0-draft`__
 - Predicate: updated
 - Subject: [`change`](#change)
 

--- a/spec.md
+++ b/spec.md
@@ -186,10 +186,12 @@ defined in the [vocabulary](#vocabulary):
 #### type (context)
 
 - Type: [`String`][typesystem]
-- Description: defines the type of event, as combination of a *subject* and
-  *predicate*. Valid event types are defined in the [vocabulary](#vocabulary).
+- Description: defines the type of event, as combination of a *subject*,
+  *predicate* and *version*. Valid event types are defined in the [vocabulary](#vocabulary).
   All event types should be prefixed with `dev.cdevents.`. One occurrence may
-  have multiple events associated, as long as they have different event types
+  have multiple events associated, as long as they have different event types.
+  *Versions* are semantic in the *major.minor* format.  For more details about versions
+  see the the see [versioning](primer.md#versioning) documentation.
 
 - Constraints:
   - REQUIRED
@@ -254,8 +256,8 @@ defined in the [vocabulary](#vocabulary):
 - Type: `String`
 - Description: The version of the CDEvents specification which the event
   uses. This enables the interpretation of the context. Compliant event
-  producers MUST use a value of `draft` when referring to this version of the
-  specification.
+  producers MUST use a value of `0.1.0-draft` when referring to this version of the
+  specification. For more details see [versioning](primer.md#versioning).
 
 - Constraints:
   - REQUIRED
@@ -268,7 +270,7 @@ This is an example of a full CDEvent context, rendered in JSON format:
 ```json
 {
     "context": {
-    "version" : "draft",
+    "version" : "0.1.0-draft",
     "id" : "A234-1234-1234",
     "source" : "/staging/tekton/",
     "type" : "dev.cdevents.taskrun.started",
@@ -353,7 +355,7 @@ The following example shows `context` and `subject` together, rendered as JSON.
 ```json
 {
    "context": {
-      "version" : "draft",
+      "version" : "0.1.0-draft",
       "id" : "A234-1234-1234",
       "source" : "/staging/tekton/",
       "type" : "dev.cdevents.taskrun.started",

--- a/spec.md
+++ b/spec.md
@@ -190,7 +190,7 @@ defined in the [vocabulary](#vocabulary):
   *predicate* and *version*. Valid event types are defined in the [vocabulary](#vocabulary).
   All event types should be prefixed with `dev.cdevents.`. One occurrence may
   have multiple events associated, as long as they have different event types.
-  *Versions* are semantic in the *major.minor* format.  For more details about versions
+  *Versions* are semantic in the *major.minor.patch* format.  For more details about versions
   see the the see [versioning](primer.md#versioning) documentation.
 
 - Constraints:


### PR DESCRIPTION
Add details about the specification versioning, the
event versioning and the schemas. Update the spec version
to 0.1.0-draft as starting in-progress version.

Update vocabulary and examples

Fixes #43 

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>