### PR TITLE
Add change to the artifact packaged event

### DIFF
--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -65,6 +65,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `abcde-12344-a2b35`, `sh0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427a1234`, `myimage@sha256:123456abcded`, `six-1.14.0-py2.py3-none-any.whl`|
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| change | `object`        | The top change of the repository from which the artifact has been built | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 
 ## Events
 

--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -65,7 +65,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `abcde-12344-a2b35`, `sh0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427a1234`, `myimage@sha256:123456abcded`, `six-1.14.0-py2.py3-none-any.whl`|
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
-| change | `object`        | The top change of the repository from which the artifact has been built | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
+| change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 
 ## Events
 

--- a/primer.md
+++ b/primer.md
@@ -89,6 +89,17 @@ create a system that will:
 * Create a coupled architecture - using point-to-point communication creates a
   tightly intertwined architecture difficult to expand and monitor.
 
+### Simplified data model
+
+In the initial version of CDEvents we tackled a simple scenario in which 
+each artifact is build from a single repository and each service is deployed
+from a single artifact.
+
+This data model is somewhat limiting, but is has allowed us to put more focus
+on the overall structure of the protocol in the first release.
+
+We plan to extend the data model to more complex scenarios in upcoming releases.
+
 ## Relations to CloudEvents
 
 CDEvents defines a [specification](./cloudevents-binding.md) that provides a set

--- a/primer.md
+++ b/primer.md
@@ -91,14 +91,15 @@ create a system that will:
 
 ### Simplified data model
 
-In the initial version of CDEvents we tackled a simple scenario in which 
-each artifact is build from a single repository and each service is deployed
+In the initial version of CDEvents we tackled a simple scenario in which
+each artifact is built from a single repository and each service is deployed
 from a single artifact.
 
-This data model is somewhat limiting, but is has allowed us to put more focus
+This data model is somewhat limited, but is has allowed us to put more focus
 on the overall structure of the protocol in the first release.
 
-We plan to extend the data model to more complex scenarios in upcoming releases.
+We plan to extend the data model to support more complex scenarios in upcoming
+releases.
 
 ## Relations to CloudEvents
 

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -52,10 +52,29 @@
           "minLength": 1
         },
         "content": {
-          "properties": {},
+          "properties": {
+            "change": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
           "additionalProperties": false,
-          "type": "object"
-        }
+          "type": "object",
+          "required": [
+            "change"
+          ]
       },
       "additionalProperties": false,
       "type": "object",

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -119,8 +119,8 @@ A branch inside the Repository was created.
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |
 
 ### `branch deleted`
 
@@ -133,8 +133,8 @@ A branch inside the Repository was deleted.
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-rep`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |
 
 ### `change created`
 
@@ -147,8 +147,8 @@ A source code change was created and submitted to a repository specific branch. 
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |
 
 ### `change reviewed`
 
@@ -161,8 +161,8 @@ Someone (user) or an automated system submitted an review to the source code cha
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |
 
 ### `change merged`
 
@@ -174,9 +174,9 @@ A change is merged to the target branch where it was submitted.
 
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |
 
 ### `change abandoned`
 
@@ -189,8 +189,8 @@ A tool or a user decides that the change has been inactive for a while and it ca
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |
 
 ### `change updated`
 
@@ -203,5 +203,5 @@ A Change has been updated, for example a new commit is added or removed from an 
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| ⚪ |
-| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ✅ |
+| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| ⚪ |
+| repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | ⚪ |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The artifact packaged event is typically produced by the build process, and should provide details about the source the artifact was built from.

While working on the artifact change field, I realised that for the change and branch events the id + source combination should also contain the repository details, otherwise it wouldn't uniquely identify a change.

I added a note in the change/branch event section and updated the examples accordingly. I think there is still value in have a repository field in those events, but I marked it as optional (it was mandatory before).

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)