### PR TITLE
Add artifactId to service events

### DIFF
--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -41,6 +41,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`|
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` |
 
 ## Events
 
@@ -100,6 +101,7 @@ This event represents a new instance of a service that has been deployed
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service is deployed| `dev`, `staging`, `production`, `ci-123`| ✅ |
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ⚪ |
 
 ### `service upgraded`
 
@@ -113,6 +115,7 @@ This event represents an existing instance of a service that has been upgraded t
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`| ✅ |
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ⚪ |
 
 ### `service rolledback`
 
@@ -126,6 +129,7 @@ This event represents an existing instance of a service that has been rolled bac
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`| ✅ |
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ⚪ |
 
 ### `service removed`
 

--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -101,7 +101,7 @@ This event represents a new instance of a service that has been deployed
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service is deployed| `dev`, `staging`, `production`, `ci-123`| ✅ |
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ⚪ |
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
 ### `service upgraded`
 
@@ -115,7 +115,7 @@ This event represents an existing instance of a service that has been upgraded t
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`| ✅ |
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ⚪ |
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
 ### `service rolledback`
 
@@ -129,7 +129,7 @@ This event represents an existing instance of a service that has been rolled bac
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`| ✅ |
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ⚪ |
+| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
 ### `service removed`
 

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -58,12 +58,6 @@
             },
             "url": {
               "type": "string"
-            },
-            "outcome": {
-              "type": "string"
-            },
-            "errors": {
-              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -74,7 +74,11 @@
             }
           },
           "additionalProperties": false,
-          "type": "object"
+          "type": "object",
+          "required": [
+            "environment",
+            "artifactId"
+          ]
         }
       },
       "additionalProperties": false,

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -68,6 +68,9 @@
               "required": [
                 "id"
               ]
+            },
+            "artifactId": {
+              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -70,7 +70,8 @@
               ]
             },
             "artifactId": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "additionalProperties": false,

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -74,7 +74,11 @@
             }
           },
           "additionalProperties": false,
-          "type": "object"
+          "type": "object",
+          "required": [
+            "environment",
+            "artifactId"
+          ]
         }
       },
       "additionalProperties": false,

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -68,6 +68,9 @@
               "required": [
                 "id"
               ]
+            },
+            "artifactId": {
+              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -70,7 +70,8 @@
               ]
             },
             "artifactId": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -74,7 +74,11 @@
             }
           },
           "additionalProperties": false,
-          "type": "object"
+          "type": "object",
+          "required": [
+            "environment",
+            "artifactId"
+          ]
         }
       },
       "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -68,6 +68,9 @@
               "required": [
                 "id"
               ]
+            },
+            "artifactId": {
+              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -70,7 +70,8 @@
               ]
             },
             "artifactId": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the artifactId to some of the service events:
- deployed
- upgraded
- rolledback

The model is that one service is associated to one artifact. As already documented in the primer.md, this is a simplified model and it may change in future versions.

The format of the artifactId in the examples is consistent with the rest of the spec for now. All artifactIds will align to the purl format in an upcoming pull request.

Fixes: #58

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)