### PR TITLE
Add package-url format for artifact IDs

### DIFF
--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -41,7 +41,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`|
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` |
+| artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
 ## Events
 
@@ -101,7 +101,7 @@ This event represents a new instance of a service that has been deployed
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service is deployed| `dev`, `staging`, `production`, `ci-123`| ✅ |
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
+| artifactId | `Purl` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
 ### `service upgraded`
 
@@ -115,7 +115,7 @@ This event represents an existing instance of a service that has been upgraded t
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`| ✅ |
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
+| artifactId | `Purl` | Identifier of the artifact deployed with this service |`pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
 ### `service rolledback`
 
@@ -129,7 +129,7 @@ This event represents an existing instance of a service that has been rolled bac
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
 | environmentId | `String` | Id of the environment where the service runs | `dev`, `staging`, `production`, `ci-123`| ✅ |
-| artifactId | `String` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
+| artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
 ### `service removed`
 

--- a/continuous-integration-pipeline-events.md
+++ b/continuous-integration-pipeline-events.md
@@ -33,7 +33,7 @@ __Note:__ The data model for `builds`, apart from `id` and `source`, only includ
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
-| artifactId | `String` | Identifier of the artifact produced by the build | `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl`|
+| artifactId | `String` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
 ### `testCase`
 
@@ -63,7 +63,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `abcde-12344-a2b35`, `sh0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427a1234`, `myimage@sha256:123456abcded`, `six-1.14.0-py2.py3-none-any.whl`|
+| id    | `String` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 
@@ -111,7 +111,7 @@ This event represents a Build task that has finished. This event will eventually
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | | ⚪ |
-| artifactId | `String` | Identifier of the artifact produced by the build | `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `-six-1.14.0-py2.py3-none-any.whl`| ⚪ |
+| artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ⚪ |
 
 🚧 The build model is work in progress.
 
@@ -200,7 +200,7 @@ The event represents an artifact that has been packaged for distribution; this a
 
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `abcde-12344-a2b35`, `sh0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427a1234`, `myimage@sha256:123456abcded`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
+| id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | | ⚪ |
 
 ### `artifact published`
@@ -213,5 +213,5 @@ The event represents an artifact that has been published and it can be advertise
 
 | Field | Type | Description | Examples | Mandatory ✅ \| Optional ⚪ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `abcde-12344-a2b35`, `sh0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427a1234`, `myimage@sha256:123456abcded`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
+| id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | | ⚪ |

--- a/primer.md
+++ b/primer.md
@@ -189,6 +189,16 @@ Once a specification is ready for release, its number if updated, the event vers
 are finalized (`-draft` is removed), schemas are updated and a git tag is created for
 this last commit.
 
+### Artifacts
+
+The specification has chosen for v0.1.0 to adopt [package-urls][purl] (or purls)
+as the format for any artifact identifier included in the spec. Purls provide a
+consistent format for artifact identifiers across different package types.
+
+CDEvents wishes for a format that can be used to reference to an artifact, or
+package, that is independent from the hosting storage, which is a property which
+purls satisfy for several artifact types.
+
 ## Acknowledgments
 
 The initial structure of the CDEvents specification format was based on the
@@ -249,3 +259,4 @@ created and its mission.
 [whitepaper]: https://cd.foundation/blog/2022/06/07/cdevents-publishes-first-whitepaper/
 [ce-design-goals]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/primer.md#design-goals
 [ce-partitioning]: https://github.com/cloudevents/spec/blob/v1.0.1/extensions/partitioning.md
+[purl]: https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst

--- a/spec.md
+++ b/spec.md
@@ -156,6 +156,7 @@ defined by the CloudEvents project, plus some CDEvents specific types
   - Keys are of type `String`. Valid keys can be defined by this spec
   - Values can be any of the other kind
   - An object key is referred to as an "attribute"
+- `Purl`: a string in [package-url][purl-spec] format
 
   Object key names are by convention defined in [CamelCase](https://en.wikipedia.org/wiki/Camel_case).
 
@@ -513,3 +514,4 @@ platforms.
 [typesystem]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system
 [datacontenttype]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#datacontenttype
 [rfc2406]: https://tools.ietf.org/html/rfc2046
+[purl-spec]: https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst


### PR DESCRIPTION
# Changes

Specify that artifact IDs are in the package-url format: https://github.com/package-url/purl-spec

Fixes: #38

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)