### PR TITLE
Fix the $schema in jsonschema files

### DIFF
--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/artifact-packaged-event",
   "properties": {
     "context": {

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -75,6 +75,7 @@
           "required": [
             "change"
           ]
+        }
       },
       "additionalProperties": false,
       "type": "object",

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/artifact-published-event",
   "properties": {
     "context": {

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/branch-created-event",
   "properties": {
     "context": {

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/branch-deleted-event",
   "properties": {
     "context": {

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/build-finished-event",
   "properties": {
     "context": {

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/build-queued-event",
   "properties": {
     "context": {

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/build-started-event",
   "properties": {
     "context": {

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/change-abandoned-event",
   "properties": {
     "context": {

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/change-created-event",
   "properties": {
     "context": {

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/change-merged-event",
   "properties": {
     "context": {

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/change-reviewed-event",
   "properties": {
     "context": {

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/change-updated-event",
   "properties": {
     "context": {

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/environment-created-event",
   "properties": {
     "context": {

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/environment-deleted-event",
   "properties": {
     "context": {

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/environment-modified-event",
   "properties": {
     "context": {

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/pipeline-run-finished-event",
   "properties": {
     "context": {

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/pipeline-run-queued-event",
   "properties": {
     "context": {

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/pipeline-run-started-event",
   "properties": {
     "context": {

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/repository-created-event",
   "properties": {
     "context": {

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/repository-deleted-event",
   "properties": {
     "context": {

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/repository-modified-event",
   "properties": {
     "context": {

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/service-deployed-event",
   "properties": {
     "context": {

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/service-published-event",
   "properties": {
     "context": {

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/service-removed-event",
   "properties": {
     "context": {

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/service-rolledback-event",
   "properties": {
     "context": {

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/service-upgraded-event",
   "properties": {
     "context": {

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/task-run-finished-event",
   "properties": {
     "context": {

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/task-run-started-event",
   "properties": {
     "context": {

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/test-case-finished-event",
   "properties": {
     "context": {

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/test-case-queued-event",
   "properties": {
     "context": {

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/test-case-started-event",
   "properties": {
     "context": {

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/test-suite-finished-event",
   "properties": {
     "context": {

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/0.1.0-draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://cdevents.dev/0.1.0-draft/schema/test-suite-started-event",
   "properties": {
     "context": {


### PR DESCRIPTION
# Changes

The $schema property was updated by mistake in search/replace of draft to v0.1.0-draft. Fixing the schema now.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)