### PR TITLE
Fix the schemas for custom data

### DIFF
--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -70,8 +70,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -86,8 +86,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -73,8 +73,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -70,8 +70,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -73,8 +73,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -79,8 +79,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -73,8 +73,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -77,8 +77,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -85,8 +85,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -79,8 +79,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -79,8 +79,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -91,8 +91,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -83,8 +83,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -83,8 +83,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -91,8 +91,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -91,8 +91,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -95,8 +95,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -89,8 +89,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -66,8 +66,15 @@
       ]
     },
     "customData": {
-      "type": "string",
-      "contentEncoding": "base64"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
     },
     "customDataContentType": {
       "type": "string"

--- a/spec.md
+++ b/spec.md
@@ -396,8 +396,8 @@ additional data in CDEvents.
   - OPTIONAL
 
 - Examples:
-  - '{"mydata1": "myvalue1"}'
-  - 'VGhlIHZvY2FidWxhcnkgZGVmaW5lcyAqZXZlbnQgdHlwZXMqLCB3aGljaCBhcmUgbWFkZSBvZiAqc3ViamVjdHMqCg=='
+  - `{"mydata1": "myvalue1"}`
+  - `"VGhlIHZvY2FidWxhcnkgZGVmaW5lcyAqZXZlbnQgdHlwZXMqLCB3aGljaCBhcmUgbWFkZSBvZiAqc3ViamVjdHMqCg=="`
 
 #### customDataContentType
 


### PR DESCRIPTION
# Changes

The current schema only includes string/base64 which is used for non JSON data. 
customData may include either JSON (object) or base64 encoded content (string).

Fix one of the examples in the spec that was possibly misleading.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)