### PR TITLE
Repo optional in branch and change schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ points for metrics.
 ## CDEvents Specification
 
 The latest release of the specification is
-[v0.1.0](https://github.com/cdevents/spec/tree/v0.1.0/spec.md), and you can
+[v0.1.1](https://github.com/cdevents/spec/tree/v0.1.1/spec.md), and you can
 continuously follow the latest updates of the specification on [the `main`
 branch](./spec.md).
 

--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -100,7 +100,7 @@ Content-Length: nnnn
 
 {
    "context": {
-      "version" : "0.1.0",
+      "version" : "0.1.1",
       "id" : "A234-1234-1234",
       "source" : "/staging/tekton/",
       "type" : "dev.cdevents.taskrun.started",

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/artifact-packaged-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/artifact-packaged-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/artifact-published-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/artifact-published-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/branch-created-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/branch-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/branch-deleted-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/branch-deleted-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/build-finished-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/build-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/build-queued-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/build-queued-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/build-started-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/build-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/change-abandoned-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/change-abandoned-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/change-created-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/change-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/change-merged-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/change-merged-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/change-reviewed-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/change-reviewed-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -71,10 +71,7 @@
             }
           },
           "additionalProperties": false,
-          "type": "object",
-          "required": [
-            "repository"
-          ]
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -7,7 +7,6 @@
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0",
             "0.1.1"
           ],
           "default": "0.1.1"

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/change-updated-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/change-updated-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/environment-created-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/environment-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/environment-deleted-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/environment-deleted-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/environment-modified-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/environment-modified-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/pipeline-run-finished-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/pipeline-run-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/pipeline-run-queued-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/pipeline-run-queued-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/pipeline-run-started-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/pipeline-run-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/repository-created-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/repository-created-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/repository-deleted-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/repository-deleted-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/repository-modified-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/repository-modified-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/service-deployed-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/service-deployed-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/service-published-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/service-published-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/service-removed-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/service-removed-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/service-rolledback-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/service-rolledback-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/service-upgraded-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/service-upgraded-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/task-run-finished-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/task-run-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/task-run-started-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/task-run-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/test-case-finished-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/test-case-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/test-case-queued-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/test-case-queued-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/test-case-started-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/test-case-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/test-suite-finished-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/test-suite-finished-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -1,15 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://cdevents.dev/0.1.0/schema/test-suite-started-event",
+  "$id": "https://cdevents.dev/0.1.1/schema/test-suite-started-event",
   "properties": {
     "context": {
       "properties": {
         "version": {
           "type": "string",
           "enum": [
-            "0.1.0"
+            "0.1.0",
+            "0.1.1"
           ],
-          "default": "0.1.0"
+          "default": "0.1.1"
         },
         "id": {
           "type": "string",

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -110,7 +110,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 A branch inside the Repository was created.
 
-- Event Type: __`dev.cdevents.branch.created.0.1.0`__
+- Event Type: __`dev.cdevents.branch.created.0.1.1`__
 - Predicate: created
 - Subject: [`branch`](#branch)
 
@@ -124,7 +124,7 @@ A branch inside the Repository was created.
 
 A branch inside the Repository was deleted.
 
-- Event Type: __`dev.cdevents.branch.deleted.0.1.0`__
+- Event Type: __`dev.cdevents.branch.deleted.0.1.1`__
 - Predicate: deleted
 - Subject: [`branch`](#branch)
 
@@ -138,7 +138,7 @@ A branch inside the Repository was deleted.
 
 A source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit.
 
-- Event Type: __`dev.cdevents.change.created.0.1.0`__
+- Event Type: __`dev.cdevents.change.created.0.1.1`__
 - Predicate: created
 - Subject: [`change`](#change)
 
@@ -152,7 +152,7 @@ A source code change was created and submitted to a repository specific branch. 
 
 Someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.
 
-- Event Type: __`dev.cdevents.change.reviewed.0.1.0`__
+- Event Type: __`dev.cdevents.change.reviewed.0.1.1`__
 - Predicate: reviewed
 - Subject: [`change`](#change)
 
@@ -166,7 +166,7 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 A change is merged to the target branch where it was submitted.
 
-- Event Type: __`dev.cdevents.change.merged.0.1.0`__
+- Event Type: __`dev.cdevents.change.merged.0.1.1`__
 - Predicate: merged
 - Subject: [`change`](#change)
 
@@ -180,7 +180,7 @@ A change is merged to the target branch where it was submitted.
 
 A tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
 
-- Event Type: __`dev.cdevents.change.abandoned.0.1.0`__
+- Event Type: __`dev.cdevents.change.abandoned.0.1.1`__
 - Predicate: abandoned
 - Subject: [`change`](#change)
 
@@ -194,7 +194,7 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 A Change has been updated, for example a new commit is added or removed from an existing Change.
 
-- Event Type: __`dev.cdevents.change.updated.0.1.0`__
+- Event Type: __`dev.cdevents.change.updated.0.1.1`__
 - Predicate: updated
 - Subject: [`change`](#change)
 

--- a/spec.md
+++ b/spec.md
@@ -253,7 +253,7 @@ defined in the [vocabulary](#vocabulary):
 - Type: `String`
 - Description: The version of the CDEvents specification which the event
   uses. This enables the interpretation of the context. Compliant event
-  producers MUST use a value of `0.1.0` when referring to this version of the
+  producers MUST use a value of `0.1.1` when referring to this version of the
   specification. For more details see [versioning](primer.md#versioning).
 
 - Constraints:
@@ -267,7 +267,7 @@ This is an example of a full CDEvent context, rendered in JSON format:
 ```json
 {
     "context": {
-    "version" : "0.1.0",
+    "version" : "0.1.1",
     "id" : "A234-1234-1234",
     "source" : "/staging/tekton/",
     "type" : "dev.cdevents.taskrun.started",
@@ -352,7 +352,7 @@ The following example shows `context` and `subject` together, rendered as JSON.
 ```json
 {
    "context": {
-      "version" : "0.1.0",
+      "version" : "0.1.1",
       "id" : "A234-1234-1234",
       "source" : "/staging/tekton/",
       "type" : "dev.cdevents.taskrun.started",


### PR DESCRIPTION
# Changes

The repository is an optional field in branch and change events, both in the specification as well as in the SDK.

This is because the source includes the repository information already. While there is value in specifying the repository reference separated from the SCM system URL, it should not be mandatory to do so.

The schema files for branch and change events specify the repository as a mandatory field. This was an oversight, which is fixed here.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)