### PR TITLE
Remove the version enums from schemas

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -209,6 +209,14 @@ format `vMajor.Minor.Patch`.
 While a version of the specification is work in progress, its version is tagged
 with an extra `-draft` at the end, for instance 0.1.0-draft.
 
+The version is in each schema as part of the schema id and it's included in
+each event in the "version" field. The version field does not include enum nor
+default values in the schema because that would require changing the event
+version every time the spec version is changed. Examples:
+
+- Schema: `"$id": "https://cdevents.dev/0.1.1/schema/artifact-packaged-event",`
+- Event: `"version": "0.1.1"`
+
 ### Development of a new version
 
 The specification on the main branch is versioned with the number of the next

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -6,10 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -6,11 +6,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "enum": [
-            "0.1.0",
-            "0.1.1"
-          ],
-          "default": "0.1.1"
+          "minLength": 1
         },
         "id": {
           "type": "string",


### PR DESCRIPTION
# Changes

Including the spec version enums in schemas is problematic, because every time the spec is updated it implies that all the event schemas must be updated as well which in turn requires the event type versions to be updated too, which is confusing since not all events are updated when a new spec version is made.

To solve that issue, we remove the enum from the version property, a let it be a non-empty string. The SDKs can use the event type and version to download the schema and validate events.

When a new spec release is made, the $id in the schema of all events still have to be updated, but that should not cause the version on the event type to be updated.

Fixes #87

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)