### PR TITLE
Fix event types in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ points for metrics.
 
 ## CDEvents Specification
 
-The latest release of the specification on this branch is
-[v0.1.1](https://github.com/cdevents/spec/tree/v0.1.1/spec.md), and you can
+The latest release of the specification on is
+[v0.1.2](https://github.com/cdevents/spec/blob/v0.1.2/spec.md), and you can
 continuously follow the latest updates of the specification on [the `main`
 branch](./spec.md).
 

--- a/continuous-deployment-pipeline-events.md
+++ b/continuous-deployment-pipeline-events.md
@@ -49,7 +49,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 This event represents an environment that has been created. Such an environment can be used to deploy services in.
 
-- Event Type: __`dev.cdevents.environment.created.0.1-draft`__
+- Event Type: __`dev.cdevents.environment.created.0.1.0`__
 - Predicate: created
 - Subject: [`environment`](#environment)
 
@@ -64,7 +64,7 @@ This event represents an environment that has been created. Such an environment 
 
 This event represents an environment that has been modified.
 
-- Event Type: __`dev.cdevents.environment.modified.0.1-draft`__
+- Event Type: __`dev.cdevents.environment.modified.0.1.0`__
 - Predicate: modified
 - Subject: [`environment`](#environment)
 
@@ -79,7 +79,7 @@ This event represents an environment that has been modified.
 
 This event represents an environment that has been deleted.```
 
-- Event Type: __`dev.cdevents.environment.deleted.0.1-draft`__
+- Event Type: __`dev.cdevents.environment.deleted.0.1.0`__
 - Predicate: deleted
 - Subject: [`environment`](#environment)
 
@@ -93,7 +93,7 @@ This event represents an environment that has been deleted.```
 
 This event represents a new instance of a service that has been deployed
 
-- Event Type: __`dev.cdevents.service.deployed.0.1-draft`__
+- Event Type: __`dev.cdevents.service.deployed.0.1.0`__
 - Predicate: deployed
 - Subject: [`service`](#service)
 
@@ -107,7 +107,7 @@ This event represents a new instance of a service that has been deployed
 
 This event represents an existing instance of a service that has been upgraded to a new version
 
-- Event Type: __`dev.cdevents.service.upgraded.0.1-draft`__
+- Event Type: __`dev.cdevents.service.upgraded.0.1.0`__
 - Predicate: upgraded
 - Subject: [`service`](#service)
 
@@ -121,7 +121,7 @@ This event represents an existing instance of a service that has been upgraded t
 
 This event represents an existing instance of a service that has been rolled back to a previous version
 
-- Event Type: __`dev.cdevents.service.rolledback.0.1-draft`__
+- Event Type: __`dev.cdevents.service.rolledback.0.1.0`__
 - Predicate: rolledback
 - Subject: [`service`](#service)
 
@@ -135,7 +135,7 @@ This event represents an existing instance of a service that has been rolled bac
 
 This event represents the removal of a previously deployed service instance and is thus not longer present in the specified environment
 
-- Event Type: __`dev.cdevents.service.removed.0.1-draft`__
+- Event Type: __`dev.cdevents.service.removed.0.1.0`__
 - Predicate: removed
 - Subject: [`service`](#service)
 
@@ -148,7 +148,7 @@ This event represents the removal of a previously deployed service instance and 
 
 This event represents an existing instance of a service that has an accessible URL for users to interact with it. This event can be used to let other tools know that the service is ready and also available for consumption.
 
-- Event Type: __`dev.cdevents.service.published.0.1-draft`__
+- Event Type: __`dev.cdevents.service.published.0.1.0`__
 - Predicate: published
 - Subject: [`service`](#service)
 

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.artifact.packaged.0.1.0"
+          ],
+          "default": "dev.cdevents.artifact.packaged.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.artifact.published.0.1.0"
+          ],
+          "default": "dev.cdevents.artifact.published.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.branch.created.0.1.1"
+          ],
+          "default": "dev.cdevents.branch.created.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.branch.deleted.0.1.1"
+          ],
+          "default": "dev.cdevents.branch.deleted.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.build.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.build.finished.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.build.queued.0.1.0"
+          ],
+          "default": "dev.cdevents.build.queued.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.build.started.0.1.0"
+          ],
+          "default": "dev.cdevents.build.started.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.change.abandoned.0.1.1"
+          ],
+          "default": "dev.cdevents.change.abandoned.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.change.created.0.1.1"
+          ],
+          "default": "dev.cdevents.change.created.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.change.merged.0.1.1"
+          ],
+          "default": "dev.cdevents.change.merged.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.change.reviewed.0.1.1"
+          ],
+          "default": "dev.cdevents.change.reviewed.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.change.updated.0.1.1"
+          ],
+          "default": "dev.cdevents.change.updated.0.1.1"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.environment.created.0.1.0"
+          ],
+          "default": "dev.cdevents.environment.created.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.environment.deleted.0.1.0"
+          ],
+          "default": "dev.cdevents.environment.deleted.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.environment.modified.0.1.0"
+          ],
+          "default": "dev.cdevents.environment.modified.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.pipelinerun.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.pipelinerun.finished.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.pipelinerun.queued.0.1.0"
+          ],
+          "default": "dev.cdevents.pipelinerun.queued.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.pipelinerun.started.0.1.0"
+          ],
+          "default": "dev.cdevents.pipelinerun.started.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.repository.created.0.1.0"
+          ],
+          "default": "dev.cdevents.repository.created.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.repository.deleted.0.1.0"
+          ],
+          "default": "dev.cdevents.repository.deleted.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.repository.modified.0.1.0"
+          ],
+          "default": "dev.cdevents.repository.modified.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.service.deployed.0.1.0"
+          ],
+          "default": "dev.cdevents.service.deployed.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.service.published.0.1.0"
+          ],
+          "default": "dev.cdevents.service.published.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.service.removed.0.1.0"
+          ],
+          "default": "dev.cdevents.service.removed.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.service.rolledback.0.1.0"
+          ],
+          "default": "dev.cdevents.service.rolledback.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.service.upgraded.0.1.0"
+          ],
+          "default": "dev.cdevents.service.upgraded.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.taskrun.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.taskrun.finished.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.taskrun.started.0.1.0"
+          ],
+          "default": "dev.cdevents.taskrun.started.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.testcase.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.testcase.finished.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.testcase.queued.0.1.0"
+          ],
+          "default": "dev.cdevents.testcase.queued.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.testcase.started.0.1.0"
+          ],
+          "default": "dev.cdevents.testcase.started.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.testsuite.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.testsuite.finished.0.1.0"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -18,7 +18,10 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "dev.cdevents.testsuite.started.0.1.0"
+          ],
+          "default": "dev.cdevents.testsuite.started.0.1.0"
         },
         "timestamp": {
           "type": "string",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cherry-pick from the v0.1.2 release.
Add tool to manage event versions.
Add event type enum/default in the schemas.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
