### PR TITLE
Enforce the source format URI-reference via the jsonschema

### DIFF
--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -49,7 +49,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 This event represents an environment that has been created. Such an environment can be used to deploy services in.
 
-- Event Type: __`dev.cdevents.environment.created.0.1.0`__
+- Event Type: __`dev.cdevents.environment.created.0.1.1`__
 - Predicate: created
 - Subject: [`environment`](#environment)
 
@@ -64,7 +64,7 @@ This event represents an environment that has been created. Such an environment 
 
 This event represents an environment that has been modified.
 
-- Event Type: __`dev.cdevents.environment.modified.0.1.0`__
+- Event Type: __`dev.cdevents.environment.modified.0.1.1`__
 - Predicate: modified
 - Subject: [`environment`](#environment)
 
@@ -79,7 +79,7 @@ This event represents an environment that has been modified.
 
 This event represents an environment that has been deleted.```
 
-- Event Type: __`dev.cdevents.environment.deleted.0.1.0`__
+- Event Type: __`dev.cdevents.environment.deleted.0.1.1`__
 - Predicate: deleted
 - Subject: [`environment`](#environment)
 
@@ -93,7 +93,7 @@ This event represents an environment that has been deleted.```
 
 This event represents a new instance of a service that has been deployed
 
-- Event Type: __`dev.cdevents.service.deployed.0.1.0`__
+- Event Type: __`dev.cdevents.service.deployed.0.1.1`__
 - Predicate: deployed
 - Subject: [`service`](#service)
 
@@ -107,7 +107,7 @@ This event represents a new instance of a service that has been deployed
 
 This event represents an existing instance of a service that has been upgraded to a new version
 
-- Event Type: __`dev.cdevents.service.upgraded.0.1.0`__
+- Event Type: __`dev.cdevents.service.upgraded.0.1.1`__
 - Predicate: upgraded
 - Subject: [`service`](#service)
 
@@ -121,7 +121,7 @@ This event represents an existing instance of a service that has been upgraded t
 
 This event represents an existing instance of a service that has been rolled back to a previous version
 
-- Event Type: __`dev.cdevents.service.rolledback.0.1.0`__
+- Event Type: __`dev.cdevents.service.rolledback.0.1.1`__
 - Predicate: rolledback
 - Subject: [`service`](#service)
 
@@ -135,7 +135,7 @@ This event represents an existing instance of a service that has been rolled bac
 
 This event represents the removal of a previously deployed service instance and is thus not longer present in the specified environment
 
-- Event Type: __`dev.cdevents.service.removed.0.1.0`__
+- Event Type: __`dev.cdevents.service.removed.0.1.1`__
 - Predicate: removed
 - Subject: [`service`](#service)
 
@@ -148,7 +148,7 @@ This event represents the removal of a previously deployed service instance and 
 
 This event represents an existing instance of a service that has an accessible URL for users to interact with it. This event can be used to let other tools know that the service is ready and also available for consumption.
 
-- Event Type: __`dev.cdevents.service.published.0.1.0`__
+- Event Type: __`dev.cdevents.service.published.0.1.1`__
 - Predicate: published
 - Subject: [`service`](#service)
 

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -73,7 +73,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 This event represents a Build task that has been queued; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.queued.0.1.0`__
+- Event Type: __`dev.cdevents.build.queued.0.1.1`__
 - Predicate: queued
 - Subject: [`build`](#build)
 
@@ -86,7 +86,7 @@ This event represents a Build task that has been queued; this build process usua
 
 This event represents a Build task that has been started; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.started.0.1.0`__
+- Event Type: __`dev.cdevents.build.started.0.1.1`__
 - Predicate: started
 - Subject: [`build`](#build)
 
@@ -99,7 +99,7 @@ This event represents a Build task that has been started; this build process usu
 
 This event represents a Build task that has finished. This event will eventually contain the finished status, success, error or failure
 
-- Event Type: __`dev.cdevents.build.finished.0.1.0`__
+- Event Type: __`dev.cdevents.build.finished.0.1.1`__
 - Predicate: finished
 - Subject: [`build`](#build)
 
@@ -113,7 +113,7 @@ This event represents a Build task that has finished. This event will eventually
 
 This event represents a Test task that has been queued, and it is waiting to be started.
 
-- Event Type: __`dev.cdevents.testcase.queued.0.1.0`__
+- Event Type: __`dev.cdevents.testcase.queued.0.1.1`__
 - Predicate: queued
 - Subject: [`testCase`](#testcase)
 
@@ -126,7 +126,7 @@ This event represents a Test task that has been queued, and it is waiting to be 
 
 This event represents a Test task that has started.
 
-- Event Type: __`dev.cdevents.testcase.started.0.1.0`__
+- Event Type: __`dev.cdevents.testcase.started.0.1.1`__
 - Predicate: started
 - Subject: [`testCase`](#testcase)
 
@@ -139,7 +139,7 @@ This event represents a Test task that has started.
 
 This event represents a Test task that has finished. This event will eventually contain the finished status: success, error or failure.
 
-- Event Type: __`dev.cdevents.testcase.finished.0.1.0`__
+- Event Type: __`dev.cdevents.testcase.finished.0.1.1`__
 - Predicate: finished
 - Subject: [`testCase`](#testcase)
 
@@ -152,7 +152,7 @@ This event represents a Test task that has finished. This event will eventually 
 
 This event represents a Test suite that has been started.
 
-- Event Type: __`dev.cdevents.testsuite.started.0.1.0`__
+- Event Type: __`dev.cdevents.testsuite.started.0.1.1`__
 - Predicate: started
 - Subject: [`testSuite`](#testsuite)
 
@@ -165,7 +165,7 @@ This event represents a Test suite that has been started.
 
 This event represents a Test suite that has has finished, the event will contain the finished status: success, error or failure.
 
-- Event Type: __`dev.cdevents.testsuite.finished.0.1.0`__
+- Event Type: __`dev.cdevents.testsuite.finished.0.1.1`__
 - Predicate: finished
 - Subject: [`testSuite`](#testsuite)
 
@@ -178,7 +178,7 @@ This event represents a Test suite that has has finished, the event will contain
 
 The event represents an artifact that has been packaged for distribution; this artifact is now versioned with a fixed version.
 
-- Event Type: __`dev.cdevents.artifact.packaged.0.1.0`__
+- Event Type: __`dev.cdevents.artifact.packaged.0.1.1`__
 - Predicate: packaged
 - Subject: [`artifact`](#artifact)
 
@@ -191,7 +191,7 @@ The event represents an artifact that has been packaged for distribution; this a
 
 The event represents an artifact that has been published and it can be advertised for others to use.
 
-- Event Type: __`dev.cdevents.artifact.published.0.1.0`__
+- Event Type: __`dev.cdevents.artifact.published.0.1.1`__
 - Predicate: published
 - Subject: [`artifact`](#artifact)
 

--- a/core.md
+++ b/core.md
@@ -66,7 +66,7 @@ Due the dynamic nature of Pipelines, most of actual work needs to be queued to
 happen in a distributed way, hence queued events are added. Adopters can choose
 to ignore these events if they don't apply to their use cases.
 
-- Event Type: __`dev.cdevents.pipelinerun.queued.0.1.0`__
+- Event Type: __`dev.cdevents.pipelinerun.queued.0.1.1`__
 - Predicate: queued
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -81,7 +81,7 @@ to ignore these events if they don't apply to their use cases.
 
 A pipelineRun has started and it is running.
 
-- Event Type: __`dev.cdevents.pipelinerun.started.0.1.0`__
+- Event Type: __`dev.cdevents.pipelinerun.started.0.1.1`__
 - Predicate: started
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -96,7 +96,7 @@ A pipelineRun has started and it is running.
 
 A pipelineRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.pipelinerun.finished.0.1.0`__
+- Event Type: __`dev.cdevents.pipelinerun.finished.0.1.1`__
 - Predicate: finished
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -113,7 +113,7 @@ A pipelineRun has finished, successfully or not.
 
 A taskRun has started and it is running.
 
-- Event Type: __`dev.cdevents.taskrun.started.0.1.0`__
+- Event Type: __`dev.cdevents.taskrun.started.0.1.1`__
 - Predicate: started
 - Subject: [`taskRun`](#taskrun)
 
@@ -129,7 +129,7 @@ A taskRun has started and it is running.
 
 A taskRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.taskrun.finished.0.1.0`__
+- Event Type: __`dev.cdevents.taskrun.finished.0.1.1`__
 - Predicate: finished
 - Subject: [`taskRun`](#taskrun)
 

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.artifact.packaged.0.1.0"
+            "dev.cdevents.artifact.packaged.0.1.1"
           ],
-          "default": "dev.cdevents.artifact.packaged.0.1.0"
+          "default": "dev.cdevents.artifact.packaged.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.artifact.published.0.1.0"
+            "dev.cdevents.artifact.published.0.1.1"
           ],
-          "default": "dev.cdevents.artifact.published.0.1.0"
+          "default": "dev.cdevents.artifact.published.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.branch.created.0.1.1"
+            "dev.cdevents.branch.created.0.1.2"
           ],
-          "default": "dev.cdevents.branch.created.0.1.1"
+          "default": "dev.cdevents.branch.created.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.branch.deleted.0.1.1"
+            "dev.cdevents.branch.deleted.0.1.2"
           ],
-          "default": "dev.cdevents.branch.deleted.0.1.1"
+          "default": "dev.cdevents.branch.deleted.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.finished.0.1.0"
+            "dev.cdevents.build.finished.0.1.1"
           ],
-          "default": "dev.cdevents.build.finished.0.1.0"
+          "default": "dev.cdevents.build.finished.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.queued.0.1.0"
+            "dev.cdevents.build.queued.0.1.1"
           ],
-          "default": "dev.cdevents.build.queued.0.1.0"
+          "default": "dev.cdevents.build.queued.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.started.0.1.0"
+            "dev.cdevents.build.started.0.1.1"
           ],
-          "default": "dev.cdevents.build.started.0.1.0"
+          "default": "dev.cdevents.build.started.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.abandoned.0.1.1"
+            "dev.cdevents.change.abandoned.0.1.2"
           ],
-          "default": "dev.cdevents.change.abandoned.0.1.1"
+          "default": "dev.cdevents.change.abandoned.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.created.0.1.1"
+            "dev.cdevents.change.created.0.1.2"
           ],
-          "default": "dev.cdevents.change.created.0.1.1"
+          "default": "dev.cdevents.change.created.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.merged.0.1.1"
+            "dev.cdevents.change.merged.0.1.2"
           ],
-          "default": "dev.cdevents.change.merged.0.1.1"
+          "default": "dev.cdevents.change.merged.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.reviewed.0.1.1"
+            "dev.cdevents.change.reviewed.0.1.2"
           ],
-          "default": "dev.cdevents.change.reviewed.0.1.1"
+          "default": "dev.cdevents.change.reviewed.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.updated.0.1.1"
+            "dev.cdevents.change.updated.0.1.2"
           ],
-          "default": "dev.cdevents.change.updated.0.1.1"
+          "default": "dev.cdevents.change.updated.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.environment.created.0.1.0"
+            "dev.cdevents.environment.created.0.1.1"
           ],
-          "default": "dev.cdevents.environment.created.0.1.0"
+          "default": "dev.cdevents.environment.created.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.environment.deleted.0.1.0"
+            "dev.cdevents.environment.deleted.0.1.1"
           ],
-          "default": "dev.cdevents.environment.deleted.0.1.0"
+          "default": "dev.cdevents.environment.deleted.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.environment.modified.0.1.0"
+            "dev.cdevents.environment.modified.0.1.1"
           ],
-          "default": "dev.cdevents.environment.modified.0.1.0"
+          "default": "dev.cdevents.environment.modified.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -65,6 +66,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },
@@ -82,6 +84,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -14,7 +14,8 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string"
@@ -62,7 +64,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,
@@ -78,7 +81,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -14,7 +14,8 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string"
@@ -62,7 +64,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,
@@ -83,7 +86,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -65,6 +66,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },
@@ -87,6 +89,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -65,6 +66,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },
@@ -82,6 +84,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -14,7 +14,8 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string"
@@ -62,7 +64,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,
@@ -78,7 +81,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.pipelinerun.finished.0.1.0"
+            "dev.cdevents.pipelinerun.finished.0.1.1"
           ],
-          "default": "dev.cdevents.pipelinerun.finished.0.1.0"
+          "default": "dev.cdevents.pipelinerun.finished.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.pipelinerun.queued.0.1.0"
+            "dev.cdevents.pipelinerun.queued.0.1.1"
           ],
-          "default": "dev.cdevents.pipelinerun.queued.0.1.0"
+          "default": "dev.cdevents.pipelinerun.queued.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.pipelinerun.started.0.1.0"
+            "dev.cdevents.pipelinerun.started.0.1.1"
           ],
-          "default": "dev.cdevents.pipelinerun.started.0.1.0"
+          "default": "dev.cdevents.pipelinerun.started.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.repository.created.0.1.0"
+            "dev.cdevents.repository.created.0.1.1"
           ],
-          "default": "dev.cdevents.repository.created.0.1.0"
+          "default": "dev.cdevents.repository.created.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.repository.deleted.0.1.0"
+            "dev.cdevents.repository.deleted.0.1.1"
           ],
-          "default": "dev.cdevents.repository.deleted.0.1.0"
+          "default": "dev.cdevents.repository.deleted.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.repository.modified.0.1.0"
+            "dev.cdevents.repository.modified.0.1.1"
           ],
-          "default": "dev.cdevents.repository.modified.0.1.0"
+          "default": "dev.cdevents.repository.modified.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.deployed.0.1.0"
+            "dev.cdevents.service.deployed.0.1.1"
           ],
-          "default": "dev.cdevents.service.deployed.0.1.0"
+          "default": "dev.cdevents.service.deployed.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.published.0.1.0"
+            "dev.cdevents.service.published.0.1.1"
           ],
-          "default": "dev.cdevents.service.published.0.1.0"
+          "default": "dev.cdevents.service.published.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.removed.0.1.0"
+            "dev.cdevents.service.removed.0.1.1"
           ],
-          "default": "dev.cdevents.service.removed.0.1.0"
+          "default": "dev.cdevents.service.removed.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.rolledback.0.1.0"
+            "dev.cdevents.service.rolledback.0.1.1"
           ],
-          "default": "dev.cdevents.service.rolledback.0.1.0"
+          "default": "dev.cdevents.service.rolledback.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -63,6 +64,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.upgraded.0.1.0"
+            "dev.cdevents.service.upgraded.0.1.1"
           ],
-          "default": "dev.cdevents.service.upgraded.0.1.0"
+          "default": "dev.cdevents.service.upgraded.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -60,7 +62,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -69,6 +70,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.taskrun.finished.0.1.0"
+            "dev.cdevents.taskrun.finished.0.1.1"
           ],
-          "default": "dev.cdevents.taskrun.finished.0.1.0"
+          "default": "dev.cdevents.taskrun.finished.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -66,7 +68,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {
@@ -69,6 +70,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "minLength": 1,
                   "format": "uri-reference"
                 }
               },

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.taskrun.started.0.1.0"
+            "dev.cdevents.taskrun.started.0.1.1"
           ],
-          "default": "dev.cdevents.taskrun.started.0.1.0"
+          "default": "dev.cdevents.taskrun.started.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
@@ -66,7 +68,8 @@
                   "minLength": 1
                 },
                 "source": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testcase.finished.0.1.0"
+            "dev.cdevents.testcase.finished.0.1.1"
           ],
-          "default": "dev.cdevents.testcase.finished.0.1.0"
+          "default": "dev.cdevents.testcase.finished.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testcase.queued.0.1.0"
+            "dev.cdevents.testcase.queued.0.1.1"
           ],
-          "default": "dev.cdevents.testcase.queued.0.1.0"
+          "default": "dev.cdevents.testcase.queued.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testcase.started.0.1.0"
+            "dev.cdevents.testcase.started.0.1.1"
           ],
-          "default": "dev.cdevents.testcase.started.0.1.0"
+          "default": "dev.cdevents.testcase.started.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuite.finished.0.1.0"
+            "dev.cdevents.testsuite.finished.0.1.1"
           ],
-          "default": "dev.cdevents.testsuite.finished.0.1.0"
+          "default": "dev.cdevents.testsuite.finished.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -47,6 +47,7 @@
         },
         "source": {
           "type": "string",
+          "minLength": 1,
           "format": "uri-reference"
         },
         "type": {

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -14,14 +14,15 @@
         },
         "source": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuite.started.0.1.0"
+            "dev.cdevents.testsuite.started.0.1.1"
           ],
-          "default": "dev.cdevents.testsuite.started.0.1.0"
+          "default": "dev.cdevents.testsuite.started.0.1.1"
         },
         "timestamp": {
           "type": "string",
@@ -45,7 +46,8 @@
           "minLength": 1
         },
         "source": {
-          "type": "string"
+          "type": "string",
+          "format": "uri-reference"
         },
         "type": {
           "type": "string",

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -63,7 +63,7 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 
 A new Source Code Repository was created to host source code for a project.
 
-- Event Type: __`dev.cdevents.repository.created.0.1.0`__
+- Event Type: __`dev.cdevents.repository.created.0.1.1`__
 - Predicate: created
 - Subject: [`repository`](#repository)
 
@@ -80,7 +80,7 @@ A new Source Code Repository was created to host source code for a project.
 
 A Source Code Repository modified some of its attributes, like location, or owner.
 
-- Event Type: __`dev.cdevents.repository.modified.0.1.0`__
+- Event Type: __`dev.cdevents.repository.modified.0.1.1`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -95,7 +95,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 ### `repository deleted`
 
-- Event Type: __`dev.cdevents.repository.deleted.0.1.0`__
+- Event Type: __`dev.cdevents.repository.deleted.0.1.1`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -112,7 +112,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 A branch inside the Repository was created.
 
-- Event Type: __`dev.cdevents.branch.created.0.1.1`__
+- Event Type: __`dev.cdevents.branch.created.0.1.2`__
 - Predicate: created
 - Subject: [`branch`](#branch)
 
@@ -126,7 +126,7 @@ A branch inside the Repository was created.
 
 A branch inside the Repository was deleted.
 
-- Event Type: __`dev.cdevents.branch.deleted.0.1.1`__
+- Event Type: __`dev.cdevents.branch.deleted.0.1.2`__
 - Predicate: deleted
 - Subject: [`branch`](#branch)
 
@@ -140,7 +140,7 @@ A branch inside the Repository was deleted.
 
 A source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit.
 
-- Event Type: __`dev.cdevents.change.created.0.1.1`__
+- Event Type: __`dev.cdevents.change.created.0.1.2`__
 - Predicate: created
 - Subject: [`change`](#change)
 
@@ -154,7 +154,7 @@ A source code change was created and submitted to a repository specific branch. 
 
 Someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.
 
-- Event Type: __`dev.cdevents.change.reviewed.0.1.1`__
+- Event Type: __`dev.cdevents.change.reviewed.0.1.2`__
 - Predicate: reviewed
 - Subject: [`change`](#change)
 
@@ -168,7 +168,7 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 A change is merged to the target branch where it was submitted.
 
-- Event Type: __`dev.cdevents.change.merged.0.1.1`__
+- Event Type: __`dev.cdevents.change.merged.0.1.2`__
 - Predicate: merged
 - Subject: [`change`](#change)
 
@@ -182,7 +182,7 @@ A change is merged to the target branch where it was submitted.
 
 A tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
 
-- Event Type: __`dev.cdevents.change.abandoned.0.1.1`__
+- Event Type: __`dev.cdevents.change.abandoned.0.1.2`__
 - Predicate: abandoned
 - Subject: [`change`](#change)
 
@@ -196,7 +196,7 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 A Change has been updated, for example a new commit is added or removed from an existing Change.
 
-- Event Type: __`dev.cdevents.change.updated.0.1.1`__
+- Event Type: __`dev.cdevents.change.updated.0.1.2`__
 - Predicate: updated
 - Subject: [`change`](#change)
 


### PR DESCRIPTION
# Changes

The format of the source field is defined as URI-reference https://github.com/cdevents/spec/blob/v0.1.1/spec.md#source-context

This is consistent with the CloudEvents specification. It reflects the fact that not every source will be an URL.

If later on, we decide on a more specific format, we can enforce it then.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer/_index.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)