### PR TITLE
Improve subject fields spec and schema

### DIFF
--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -27,9 +27,9 @@ An `environment` is a platform which may run a `service`.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](../spec.md#type-subject) | `environment` |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](spec.md#type-subject) | `environment` |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`|
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`|
 
@@ -39,9 +39,9 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](../spec.md#type-subject) | `service` |
+| id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](spec.md#type-subject) | `service` |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
@@ -57,9 +57,9 @@ This event represents an environment that has been created. Such an environment 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -73,9 +73,9 @@ This event represents an environment that has been modified.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -89,9 +89,9 @@ This event represents an environment that has been deleted.```
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 
 ### `service deployed`
@@ -104,9 +104,9 @@ This event represents a new instance of a service that has been deployed
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
+| id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
@@ -120,9 +120,9 @@ This event represents an existing instance of a service that has been upgraded t
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `service` | |
+| id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |`pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
@@ -136,9 +136,9 @@ This event represents an existing instance of a service that has been rolled bac
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `service` | |
+| id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
@@ -152,9 +152,9 @@ This event represents the removal of a previously deployed service instance and 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `service` | |
+| id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 
 ### `service published`
@@ -167,7 +167,7 @@ This event represents an existing instance of a service that has an accessible U
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `service` | |
+| id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |

--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -27,8 +27,9 @@ An `environment` is a platform which may run a `service`.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](../spec.md#type-subject) | `environment` |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`|
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`|
 
@@ -38,8 +39,9 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](../spec.md#type-subject) | `service` |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
@@ -55,8 +57,9 @@ This event represents an environment that has been created. Such an environment 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -70,8 +73,9 @@ This event represents an environment that has been modified.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -85,8 +89,9 @@ This event represents an environment that has been deleted.```
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 
 ### `service deployed`
@@ -99,7 +104,9 @@ This event represents a new instance of a service that has been deployed
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `environment` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
@@ -113,7 +120,9 @@ This event represents an existing instance of a service that has been upgraded t
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |`pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
@@ -127,7 +136,9 @@ This event represents an existing instance of a service that has been rolled bac
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
@@ -141,7 +152,9 @@ This event represents the removal of a previously deployed service instance and 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 
 ### `service published`
@@ -154,5 +167,7 @@ This event represents an existing instance of a service that has an accessible U
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -31,8 +31,9 @@ __Note:__ The data model for `builds`, apart from `id` and `source`, only includ
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](../spec.md#type-subject) | `build` |
 | artifactId | `String` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
 ### `testCase`
@@ -43,8 +44,9 @@ __Note:__ The data model for `testCase` only includes `id` and `source`, inputs 
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](../spec.md#type-subject) | `testCase` |
 
 ### `testSuite`
 
@@ -54,8 +56,9 @@ __Note:__ The data model for `testSuite` only includes `id` and `source`, inputs
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unit`, `e2e`, `security` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| id    | `String` | See [id](../spec.md#id-subject)| `unit`, `e2e`, `security` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](../spec.md#type-subject) | `testSuite` |
 
 ### `artifact`
 
@@ -63,8 +66,9 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| id    | `String` | See [id](../spec.md#id-subject)| `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](../spec.md#type-subject) | `artifact` |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 
 ## Events
@@ -79,8 +83,9 @@ This event represents a Build task that has been queued; this build process usua
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `build` | |
 
 ### `build started`
 
@@ -92,8 +97,9 @@ This event represents a Build task that has been started; this build process usu
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `build` | |
 
 ### `build finished`
 
@@ -105,9 +111,10 @@ This event represents a Build task that has finished. This event will eventually
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
-| artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | |
+| artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | `build` | |
 
 ### `testCase queued`
 
@@ -119,8 +126,9 @@ This event represents a Test task that has been queued, and it is waiting to be 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `testCase` | |
 
 ### `testCase started`
 
@@ -132,8 +140,9 @@ This event represents a Test task that has started.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `testCase` | |
 
 ### `testCase finished`
 
@@ -145,8 +154,9 @@ This event represents a Test task that has finished. This event will eventually 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `testCase` | |
 
 ### `testSuite started`
 
@@ -158,8 +168,9 @@ This event represents a Test suite that has been started.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unit`, `e2e`, `security` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `unit`, `e2e`, `security` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `testSuite` | |
 
 ### `testSuite finished`
 
@@ -171,8 +182,9 @@ This event represents a Test suite that has has finished, the event will contain
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `unit`, `e2e`, `security` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `unit`, `e2e`, `security` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `testSuite` | |
 
 ### `artifact packaged`
 
@@ -185,8 +197,13 @@ The event represents an artifact that has been packaged for distribution; this a
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
+<<<<<<< HEAD
 | source | `URI-Reference` | [source](../spec.md#source) from the context | | |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` | ✅ |
+=======
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `artifact` | |
+>>>>>>> c555c8e (Improve subject fields spec and schema)
 
 ### `artifact published`
 
@@ -199,4 +216,5 @@ The event represents an artifact that has been published and it can be advertise
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `artifact` | |

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -31,9 +31,9 @@ __Note:__ The data model for `builds`, apart from `id` and `source`, only includ
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](../spec.md#type-subject) | `build` |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](spec.md#type-subject) | `build` |
 | artifactId | `String` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
 ### `testCase`
@@ -44,9 +44,9 @@ __Note:__ The data model for `testCase` only includes `id` and `source`, inputs 
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](../spec.md#type-subject) | `testCase` |
+| id    | `String` | See [id](spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](spec.md#type-subject) | `testCase` |
 
 ### `testSuite`
 
@@ -56,9 +56,9 @@ __Note:__ The data model for `testSuite` only includes `id` and `source`, inputs
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unit`, `e2e`, `security` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](../spec.md#type-subject) | `testSuite` |
+| id    | `String` | See [id](spec.md#id-subject)| `unit`, `e2e`, `security` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](spec.md#type-subject) | `testSuite` |
 
 ### `artifact`
 
@@ -66,9 +66,9 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](../spec.md#type-subject) | `artifact` |
+| id    | `String` | See [id](spec.md#id-subject)| `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
+| type | `String` | See [type](spec.md#type-subject) | `artifact` |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 
 ## Events
@@ -83,9 +83,9 @@ This event represents a Build task that has been queued; this build process usua
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `build` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `build` | |
 
 ### `build started`
 
@@ -97,9 +97,9 @@ This event represents a Build task that has been started; this build process usu
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `build` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `build` | |
 
 ### `build finished`
 
@@ -111,9 +111,9 @@ This event represents a Build task that has finished. This event will eventually
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | |
 | artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | `build` | |
 
 ### `testCase queued`
@@ -126,9 +126,9 @@ This event represents a Test task that has been queued, and it is waiting to be 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `testCase` | |
+| id    | `String` | See [id](spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `testCase` | |
 
 ### `testCase started`
 
@@ -140,9 +140,9 @@ This event represents a Test task that has started.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `testCase` | |
+| id    | `String` | See [id](spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `testCase` | |
 
 ### `testCase finished`
 
@@ -154,9 +154,9 @@ This event represents a Test task that has finished. This event will eventually 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `testCase` | |
+| id    | `String` | See [id](spec.md#id-subject)| `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `testCase` | |
 
 ### `testSuite started`
 
@@ -168,9 +168,9 @@ This event represents a Test suite that has been started.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unit`, `e2e`, `security` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `testSuite` | |
+| id    | `String` | See [id](spec.md#id-subject)| `unit`, `e2e`, `security` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `testSuite` | |
 
 ### `testSuite finished`
 
@@ -182,9 +182,9 @@ This event represents a Test suite that has has finished, the event will contain
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `unit`, `e2e`, `security` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `testSuite` | |
+| id    | `String` | See [id](spec.md#id-subject)| `unit`, `e2e`, `security` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `testSuite` | |
 
 ### `artifact packaged`
 
@@ -196,14 +196,10 @@ The event represents an artifact that has been packaged for distribution; this a
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
-<<<<<<< HEAD
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `artifact` | |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` | ✅ |
-=======
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `artifact` | |
->>>>>>> c555c8e (Improve subject fields spec and schema)
 
 ### `artifact published`
 
@@ -215,6 +211,6 @@ The event represents an artifact that has been published and it can be advertise
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `artifact` | |
+| id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `artifact` | |

--- a/continuous-operations.md
+++ b/continuous-operations.md
@@ -26,8 +26,9 @@ An `incident` represents a problem in a production environment.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`|
+| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`|
+| type | `String` | See [type](../spec.md#type-subject) | `incident` |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` |
@@ -45,8 +46,9 @@ This event represents an incident that has been detected by a system or human.
 
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
+| type | `String` | See [type](../spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |
@@ -62,8 +64,9 @@ This event represents an incident that has been reported through a ticketing sys
 
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
+| type | `String` | See [type](../spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | ticketURI | `URI` | URI of the ticket |  `example.issues.com/ticket123` | ✅ |
@@ -80,8 +83,9 @@ This event represents an incident that has been resolved, meaning that the probl
 
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
+| type | `String` | See [type](../spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident resolution | "Response time restored below 10ms", "CVE-123 acknowledged as non-exploitable" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |

--- a/continuous-operations.md
+++ b/continuous-operations.md
@@ -26,9 +26,9 @@ An `incident` represents a problem in a production environment.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`|
-| type | `String` | See [type](../spec.md#type-subject) | `incident` |
+| id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`|
+| type | `String` | See [type](spec.md#type-subject) | `incident` |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` |
@@ -46,9 +46,9 @@ This event represents an incident that has been detected by a system or human.
 
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
-| type | `String` | See [type](../spec.md#type-subject) | `incident` | |
+| id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
+| type | `String` | See [type](spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |
@@ -64,9 +64,9 @@ This event represents an incident that has been reported through a ticketing sys
 
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
-| type | `String` | See [type](../spec.md#type-subject) | `incident` | |
+| id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
+| type | `String` | See [type](spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | ticketURI | `URI` | URI of the ticket |  `example.issues.com/ticket123` | ✅ |
@@ -83,9 +83,9 @@ This event represents an incident that has been resolved, meaning that the probl
 
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
-| type | `String` | See [type](../spec.md#type-subject) | `incident` | |
+| id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
+| type | `String` | See [type](spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident resolution | "Response time restored below 10ms", "CVE-123 acknowledged as non-exploitable" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |

--- a/core.md
+++ b/core.md
@@ -32,9 +32,9 @@ track the build and release progress on a particular software artifact.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | |
-| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | |
+| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | outcome | `Enum` | outcome of a finished `pipelineRun` | `success`, `error` or `failure`|
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` |
@@ -51,9 +51,9 @@ associated, in which case it is acceptable to generate only taskRun events.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | |
-| type | `String` | See [type](../spec.md#type-subject) | `taskRun` |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | |
+| type | `String` | See [type](spec.md#type-subject) | `taskRun` |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`|
 | outcome | `Enum` | outcome of a finished `taskRun` | `success`, `error` or `failure`|
@@ -74,9 +74,9 @@ to ignore these events if they don't apply to their use cases.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` | |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -90,9 +90,9 @@ A pipelineRun has started and it is running.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` | |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -106,9 +106,9 @@ A pipelineRun has finished, successfully or not.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
-| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` | |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 | outcome | `Enum` | outcome of a finished `pipelineRun` | `success`, `error` or `failure`| |
@@ -124,9 +124,9 @@ A taskRun has started and it is running.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
 | source | `URI-Reference` | [source](spec.md#source) from the context | | |
-| type | `String` | See [type](../spec.md#type-subject) | `taskRun` | |
+| type | `String` | See [type](spec.md#type-subject) | `taskRun` | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`| |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |
@@ -141,9 +141,9 @@ A taskRun has finished, successfully or not.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
+| id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
 | source | `URI-Reference` | [source](spec.md#source) from the context | | |
-| type | `String` | See [type](../spec.md#type-subject) | `taskRun` | |
+| type | `String` | See [type](spec.md#type-subject) | `taskRun` | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`| |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |

--- a/core.md
+++ b/core.md
@@ -32,8 +32,9 @@ track the build and release progress on a particular software artifact.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | |
+| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | outcome | `Enum` | outcome of a finished `pipelineRun` | `success`, `error` or `failure`|
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` |
@@ -50,8 +51,9 @@ associated, in which case it is acceptable to generate only taskRun events.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/taskrun-1234` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | |
+| type | `String` | See [type](../spec.md#type-subject) | `taskRun` |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`|
 | outcome | `Enum` | outcome of a finished `taskRun` | `success`, `error` or `failure`|
@@ -72,8 +74,9 @@ to ignore these events if they don't apply to their use cases.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -87,8 +90,9 @@ A pipelineRun has started and it is running.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -102,8 +106,9 @@ A pipelineRun has finished, successfully or not.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | | |
+| type | `String` | See [type](../spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 | outcome | `Enum` | outcome of a finished `pipelineRun` | `success`, `error` or `failure`| |
@@ -119,8 +124,9 @@ A taskRun has started and it is running.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
 | source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| type | `String` | See [type](../spec.md#type-subject) | `taskRun` | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`| |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |
@@ -135,8 +141,9 @@ A taskRun has finished, successfully or not.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
+| id    | `String` | See [id](../spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
 | source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| type | `String` | See [type](../spec.md#type-subject) | `taskRun` | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`| |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "artifact"
+          ],
+          "default": "artifact"
         },
         "content": {
           "properties": {

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "artifact"
+          ],
+          "default": "artifact"
         },
         "content": {
           "properties": {},

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "branch"
+          ],
+          "default": "branch"
         },
         "content": {
           "properties": {

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "branch"
+          ],
+          "default": "branch"
         },
         "content": {
           "properties": {

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "build"
+          ],
+          "default": "build"
         },
         "content": {
           "properties": {

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "build"
+          ],
+          "default": "build"
         },
         "content": {
           "properties": {},

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "build"
+          ],
+          "default": "build"
         },
         "content": {
           "properties": {},

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "change"
+          ],
+          "default": "change"
         },
         "content": {
           "properties": {

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "change"
+          ],
+          "default": "change"
         },
         "content": {
           "properties": {

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "change"
+          ],
+          "default": "change"
         },
         "content": {
           "properties": {

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "change"
+          ],
+          "default": "change"
         },
         "content": {
           "properties": {

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "change"
+          ],
+          "default": "change"
         },
         "content": {
           "properties": {

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "environment"
+          ],
+          "default": "environment"
         },
         "content": {
           "properties": {

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "environment"
+          ],
+          "default": "environment"
         },
         "content": {
           "properties": {

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "environment"
+          ],
+          "default": "environment"
         },
         "content": {
           "properties": {

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -51,7 +51,12 @@
           "format": "uri-reference"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "enum": [
+            "incident"
+          ],
+          "default": "incident"
         },
         "content": {
           "properties": {

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -51,7 +51,12 @@
           "format": "uri-reference"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "enum": [
+            "incident"
+          ],
+          "default": "incident"
         },
         "content": {
           "properties": {

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -51,7 +51,12 @@
           "format": "uri-reference"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "enum": [
+            "incident"
+          ],
+          "default": "incident"
         },
         "content": {
           "properties": {

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "pipelineRun"
+          ],
+          "default": "pipelineRun"
         },
         "content": {
           "properties": {

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "pipelineRun"
+          ],
+          "default": "pipelineRun"
         },
         "content": {
           "properties": {

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "pipelineRun"
+          ],
+          "default": "pipelineRun"
         },
         "content": {
           "properties": {

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "repository"
+          ],
+          "default": "repository"
         },
         "content": {
           "properties": {

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "repository"
+          ],
+          "default": "repository"
         },
         "content": {
           "properties": {

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "repository"
+          ],
+          "default": "repository"
         },
         "content": {
           "properties": {

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "service"
+          ],
+          "default": "service"
         },
         "content": {
           "properties": {

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "service"
+          ],
+          "default": "service"
         },
         "content": {
           "properties": {

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "service"
+          ],
+          "default": "service"
         },
         "content": {
           "properties": {

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "service"
+          ],
+          "default": "service"
         },
         "content": {
           "properties": {

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "service"
+          ],
+          "default": "service"
         },
         "content": {
           "properties": {

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "taskRun"
+          ],
+          "default": "taskRun"
         },
         "content": {
           "properties": {

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "taskRun"
+          ],
+          "default": "taskRun"
         },
         "content": {
           "properties": {

--- a/schemas/testcasefinished.json
+++ b/schemas/testcasefinished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "testCase"
+          ],
+          "default": "testCase"
         },
         "content": {
           "properties": {},

--- a/schemas/testcasequeued.json
+++ b/schemas/testcasequeued.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "testCase"
+          ],
+          "default": "testCase"
         },
         "content": {
           "properties": {},

--- a/schemas/testcasestarted.json
+++ b/schemas/testcasestarted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "testCase"
+          ],
+          "default": "testCase"
         },
         "content": {
           "properties": {},

--- a/schemas/testsuitefinished.json
+++ b/schemas/testsuitefinished.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "testSuite"
+          ],
+          "default": "testSuite"
         },
         "content": {
           "properties": {},

--- a/schemas/testsuitestarted.json
+++ b/schemas/testsuitestarted.json
@@ -52,7 +52,11 @@
         },
         "type": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "enum": [
+            "testSuite"
+          ],
+          "default": "testSuite"
         },
         "content": {
           "properties": {},

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -30,9 +30,9 @@ An SCM `repository` is identified by a `name`, an `owner` which can be a user or
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`|
-| type | `String` | See [type](../spec.md#type-subject) | `repository` |
+| id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
+| type | `String` | See [type](spec.md#type-subject) | `repository` |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`|
 | url | `URI` | URL to the `repository` for API operations. This URL needs to include the protocol used to connect to the repository. | `git://my-git.example/an-org/a-repo` |
@@ -44,9 +44,9 @@ A `branch` in an SCM repository is identified by its `id`.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`|
-| type | `String` | See [type](../spec.md#type-subject) | `branch` |
+| id    | `String` | See [id](spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
+| type | `String` | See [type](spec.md#type-subject) | `branch` |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ### `change`
@@ -55,9 +55,9 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`|
-| type | `String` | See [type](../spec.md#type-subject) | `change` |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
+| type | `String` | See [type](spec.md#type-subject) | `change` |
 | repository | `Object` ([`repository`](#repository)) | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ## Events
@@ -72,9 +72,9 @@ A new Source Code Repository was created to host source code for a project.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`| |
-| type | `String` | See [type](../spec.md#type-subject) | `repository` | |
+| id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`| |
+| type | `String` | See [type](spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -90,9 +90,9 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`| |
-| type | `String` | See [type](../spec.md#type-subject) | `repository` | |
+| id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`| |
+| type | `String` | See [type](spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -106,9 +106,9 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`| |
-| type | `String` | See [type](../spec.md#type-subject) | `repository` | |
+| id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`| |
+| type | `String` | See [type](spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | |
@@ -124,9 +124,9 @@ A branch inside the Repository was created.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](../spec.md#type-subject) | `branch` | |
+| id    | `String` | See [id](spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](spec.md#type-subject) | `branch` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `branch deleted`
@@ -139,9 +139,9 @@ A branch inside the Repository was deleted.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-rep`| |
-| type | `String` | See [type](../spec.md#type-subject) | `branch` | |
+| id    | `String` | See [id](spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-rep`| |
+| type | `String` | See [type](spec.md#type-subject) | `branch` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change created`
@@ -154,9 +154,9 @@ A source code change was created and submitted to a repository specific branch. 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](../spec.md#type-subject) | `change` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change reviewed`
@@ -169,9 +169,9 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](../spec.md#type-subject) | `change` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change merged`
@@ -184,9 +184,9 @@ A change is merged to the target branch where it was submitted.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](../spec.md#type-subject) | `change` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change abandoned`
@@ -199,9 +199,9 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](../spec.md#type-subject) | `change` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change updated`
@@ -214,7 +214,7 @@ A Change has been updated, for example a new commit is added or removed from an 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](../spec.md#type-subject) | `change` | |
+| id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -30,8 +30,9 @@ An SCM `repository` is identified by a `name`, an `owner` which can be a user or
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`|
+| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`|
+| type | `String` | See [type](../spec.md#type-subject) | `repository` |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`|
 | url | `URI` | URL to the `repository` for API operations. This URL needs to include the protocol used to connect to the repository. | `git://my-git.example/an-org/a-repo` |
@@ -43,8 +44,9 @@ A `branch` in an SCM repository is identified by its `id`.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`|
+| id    | `String` | See [id](../spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`|
+| type | `String` | See [type](../spec.md#type-subject) | `branch` |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ### `change`
@@ -53,8 +55,9 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`|
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`|
+| type | `String` | See [type](../spec.md#type-subject) | `change` |
 | repository | `Object` ([`repository`](#repository)) | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ## Events
@@ -69,8 +72,9 @@ A new Source Code Repository was created to host source code for a project.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`| |
+| type | `String` | See [type](../spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -86,8 +90,9 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`| |
+| type | `String` | See [type](../spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -101,8 +106,9 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example`| |
+| type | `String` | See [type](../spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | |
@@ -118,8 +124,9 @@ A branch inside the Repository was created.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](../spec.md#type-subject) | `branch` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `branch deleted`
@@ -132,8 +139,9 @@ A branch inside the Repository was deleted.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-rep`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-rep`| |
+| type | `String` | See [type](../spec.md#type-subject) | `branch` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change created`
@@ -146,8 +154,9 @@ A source code change was created and submitted to a repository specific branch. 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](../spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change reviewed`
@@ -160,8 +169,9 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](../spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change merged`
@@ -174,8 +184,9 @@ A change is merged to the target branch where it was submitted.
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](../spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change abandoned`
@@ -188,8 +199,9 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](../spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change updated`
@@ -202,6 +214,7 @@ A Change has been updated, for example a new commit is added or removed from an 
 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
-| id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| id    | `String` | See [id](../spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
+| source | `URI-Reference` | See [source](../spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
+| type | `String` | See [type](../spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |


### PR DESCRIPTION
# Changes

Improve the spec of subject fields for all events:
- link id and source to their spec definitions
- add the type, linked to its spec definition
- include the value of the type for each event

Improve the jsonschema by constraining the subject type field to the only valid value for each event.

Since all events have been patched already in
v0.2-draft, there's not need to +1 the version
number again within the same spec release.

Fixes: #113 

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer/_index.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)