### PR TITLE
Fix source from the context links

### DIFF
--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -28,7 +28,7 @@ An `environment` is a platform which may run a `service`.
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `staging/tekton`, `tekton-dev-123`|
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`|
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`|
 
@@ -39,7 +39,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `service/myapp`, `daemonset/myapp` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `staging/tekton`, `tekton-dev-123`|
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
@@ -56,7 +56,7 @@ This event represents an environment that has been created. Such an environment 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -71,7 +71,7 @@ This event represents an environment that has been modified.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -86,7 +86,7 @@ This event represents an environment that has been deleted.```
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 
 ### `service deployed`

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -32,7 +32,7 @@ __Note:__ The data model for `builds`, apart from `id` and `source`, only includ
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `staging/tekton`, `tekton-dev-123`|
 | artifactId | `String` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
 ### `testCase`
@@ -44,7 +44,7 @@ __Note:__ The data model for `testCase` only includes `id` and `source`, inputs 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `staging/tekton`, `tekton-dev-123`|
 
 ### `testSuite`
 
@@ -55,7 +55,7 @@ __Note:__ The data model for `testSuite` only includes `id` and `source`, inputs
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unit`, `e2e`, `security` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `staging/tekton`, `tekton-dev-123`|
 
 ### `artifact`
 
@@ -64,7 +64,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `staging/tekton`, `tekton-dev-123`|
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 
 ## Events
@@ -80,7 +80,7 @@ This event represents a Build task that has been queued; this build process usua
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `build started`
 
@@ -93,7 +93,7 @@ This event represents a Build task that has been started; this build process usu
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `build finished`
 
@@ -106,7 +106,7 @@ This event represents a Build task that has finished. This event will eventually
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | |
 
 ### `testCase queued`
@@ -120,7 +120,7 @@ This event represents a Test task that has been queued, and it is waiting to be 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `testCase started`
 
@@ -133,7 +133,7 @@ This event represents a Test task that has started.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `testCase finished`
 
@@ -146,7 +146,7 @@ This event represents a Test task that has finished. This event will eventually 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unitest-abc`, `e2e-test1`, `scan-image1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `testSuite started`
 
@@ -159,7 +159,7 @@ This event represents a Test suite that has been started.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unit`, `e2e`, `security` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `testSuite finished`
 
@@ -172,7 +172,7 @@ This event represents a Test suite that has has finished, the event will contain
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `unit`, `e2e`, `security` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 
 ### `artifact packaged`
 
@@ -185,7 +185,7 @@ The event represents an artifact that has been packaged for distribution; this a
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` | ✅ |
 
 ### `artifact published`
@@ -199,4 +199,4 @@ The event represents an artifact that has been published and it can be advertise
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | Uniquely identifies the subject within the source. | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |

--- a/continuous-operations.md
+++ b/continuous-operations.md
@@ -27,7 +27,7 @@ An `incident` represents a problem in a production environment.
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `region1/production`, `monitoring-system/metricA`|
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` |
@@ -46,7 +46,7 @@ This event represents an incident that has been detected by a system or human.
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `region1/production`, `monitoring-system/metricA`| |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |
@@ -63,7 +63,7 @@ This event represents an incident that has been reported through a ticketing sys
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `region1/production`, `monitoring-system/metricA`| |
 | description | `String` | Short, free style description of the incident | "Response time above 10ms", "New CVE-123 detected" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | ticketURI | `URI` | URI of the ticket |  `example.issues.com/ticket123` | ✅ |
@@ -81,7 +81,7 @@ This event represents an incident that has been resolved, meaning that the probl
 | Field | Type | Description | Examples | Mandatory ✅ |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `region1/production`, `monitoring-system/metricA`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `region1/production`, `monitoring-system/metricA`| |
 | description | `String` | Short, free style description of the incident resolution | "Response time restored below 10ms", "CVE-123 acknowledged as non-exploitable" | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |

--- a/core.md
+++ b/core.md
@@ -33,7 +33,7 @@ track the build and release progress on a particular software artifact.
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | outcome | `Enum` | outcome of a finished `pipelineRun` | `success`, `error` or `failure`|
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` |
@@ -51,7 +51,7 @@ associated, in which case it is acceptable to generate only taskRun events.
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/taskrun-1234` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`|
 | outcome | `Enum` | outcome of a finished `taskRun` | `success`, `error` or `failure`|
@@ -73,7 +73,7 @@ to ignore these events if they don't apply to their use cases.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -88,7 +88,7 @@ A pipelineRun has started and it is running.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -103,7 +103,7 @@ A pipelineRun has finished, successfully or not.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | | |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 | outcome | `Enum` | outcome of a finished `pipelineRun` | `success`, `error` or `failure`| |

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -31,7 +31,7 @@ An SCM `repository` is identified by a `name`, an `owner` which can be a user or
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example`|
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`|
 | url | `URI` | URL to the `repository` for API operations. This URL needs to include the protocol used to connect to the repository. | `git://my-git.example/an-org/a-repo` |
@@ -44,7 +44,7 @@ A `branch` in an SCM repository is identified by its `id`.
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example`|
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ### `change`
@@ -54,7 +54,7 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`|
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example`|
 | repository | `Object` ([`repository`](#repository)) | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ## Events
@@ -70,7 +70,7 @@ A new Source Code Repository was created to host source code for a project.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example`| |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -87,7 +87,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example`| |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -102,7 +102,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example`| |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | |
@@ -119,7 +119,7 @@ A branch inside the Repository was created.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-repo`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `branch deleted`
@@ -133,7 +133,7 @@ A branch inside the Repository was deleted.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `main`, `feature-a`, `fix-issue-1` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-rep`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-rep`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change created`
@@ -147,7 +147,7 @@ A source code change was created and submitted to a repository specific branch. 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-repo`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change reviewed`
@@ -161,7 +161,7 @@ Someone (user) or an automated system submitted an review to the source code cha
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-repo`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change merged`
@@ -175,7 +175,7 @@ A change is merged to the target branch where it was submitted.
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-repo`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change abandoned`
@@ -189,7 +189,7 @@ A tool or a user decides that the change has been inactive for a while and it ca
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-repo`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### `change updated`
@@ -203,5 +203,5 @@ A Change has been updated, for example a new commit is added or removed from an 
 | Field | Type | Description | Examples | Required |
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `featureBranch123` | ✅ |
-| source | `URI-Reference` | [source](../spec.md#source) from the context | `my-git.example/an-org/a-repo`| |
+| source | `URI-Reference` | [source](/spec.md#source-context) from the context | `my-git.example/an-org/a-repo`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |


### PR DESCRIPTION
# Changes
It seems there was change where spec.md located in directory stucture and also there are 2 sources; one for the context, another for the subject in spec.md. So, current links give 404 errors.

This remedies the problem.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer/_index.md) been updated if a design decision is involved
- [ ] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [ ] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer/_index.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)