### PR TITLE
Sets expectations for testcaserun predicates

### DIFF
--- a/testing-events.md
+++ b/testing-events.md
@@ -16,7 +16,11 @@ Testing events covers the subjects and predicates related to test-execution perf
 
 ## Subjects
 
-This specification defines three subjects in this stage: `testCaseRun`, `testSuiteRun` and `testOutput`.
+This specification defines three subjects in this stage: `testCaseRun`, `testSuiteRun` and `testOutput`. When a producer sends `testCaseRun` or `testSuiteRun` messages, they should meet the following expecations:
+- a `queued` event may optionally be followed by a `started` event
+- a `queued` event must be followed by a `finished` event
+- a `started` event must be followed by a `finished` event
+- a `finished` event may be sent independent of a `queued` or `started` event
 
 | Subject                         | Description                                  | Predicates                                                                                                 |
 |---------------------------------|----------------------------------------------|------------------------------------------------------------------------------------------------------------|

--- a/testing-events.md
+++ b/testing-events.md
@@ -16,7 +16,7 @@ Testing events covers the subjects and predicates related to test-execution perf
 
 ## Subjects
 
-This specification defines three subjects in this stage: `testCaseRun`, `testSuiteRun` and `testOutput`. When a producer sends `testCaseRun` or `testSuiteRun` messages, they should meet the following expecations:
+This specification defines three subjects in this stage: `testCaseRun`, `testSuiteRun` and `testOutput`. When a producer sends `testCaseRun` or `testSuiteRun` messages, they should meet the following expectations:
 - a `queued` event may optionally be followed by a `started` event
 - a `queued` event must be followed by either a `started` or a `finished` event
 - a `finished` event following after a `queued` event without a `started` event in between, can only have its outcome set to `cancel` or `skip`

--- a/testing-events.md
+++ b/testing-events.md
@@ -18,9 +18,10 @@ Testing events covers the subjects and predicates related to test-execution perf
 
 This specification defines three subjects in this stage: `testCaseRun`, `testSuiteRun` and `testOutput`. When a producer sends `testCaseRun` or `testSuiteRun` messages, they should meet the following expecations:
 - a `queued` event may optionally be followed by a `started` event
-- a `queued` event must be followed by a `finished` event
+- a `queued` event must be followed by either a `started` or a `finished` event
+- a `finished` event following after a `queued` event without a `started` event in between, can only have its outcome set to `cancel` (or `skip` if that is available in the protocol)
 - a `started` event must be followed by a `finished` event
-- a `finished` event may be sent independent of a `queued` or `started` event
+- a `finished` event may not be sent if no `queued` or `started` events are sent for the same subject
 
 | Subject                         | Description                                  | Predicates                                                                                                 |
 |---------------------------------|----------------------------------------------|------------------------------------------------------------------------------------------------------------|

--- a/testing-events.md
+++ b/testing-events.md
@@ -19,7 +19,7 @@ Testing events covers the subjects and predicates related to test-execution perf
 This specification defines three subjects in this stage: `testCaseRun`, `testSuiteRun` and `testOutput`. When a producer sends `testCaseRun` or `testSuiteRun` messages, they should meet the following expecations:
 - a `queued` event may optionally be followed by a `started` event
 - a `queued` event must be followed by either a `started` or a `finished` event
-- a `finished` event following after a `queued` event without a `started` event in between, can only have its outcome set to `cancel` (or `skip` if that is available in the protocol)
+- a `finished` event following after a `queued` event without a `started` event in between, can only have its outcome set to `cancel` or `skip`
 - a `started` event must be followed by a `finished` event
 - a `finished` event may not be sent if no `queued` or `started` events are sent for the same subject
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The documentation update sets expecations on the sequence of expected test events.

This update was triggered by discussions in
https://github.com/cdevents/spec/issues/140

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer/_index.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)