### PR TITLE
Add change.created description field

### DIFF
--- a/examples/change_created.json
+++ b/examples/change_created.json
@@ -3,7 +3,7 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.change.created.0.1.2",
+    "type": "dev.cdevents.change.created.0.2.0",
     "timestamp": "2023-03-20T14:27:05.315384Z"
   },
   "subject": {
@@ -11,6 +11,7 @@
     "source": "/event/source/123",
     "type": "change",
     "content": {
+      "description": "This PR address a bug from a recent PR",
       "repository": {
         "id": "TestRepo/TestOrg",
         "source": "https://example.org"

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -20,9 +20,9 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.created.0.1.2"
+            "dev.cdevents.change.created.0.2.0"
           ],
-          "default": "dev.cdevents.change.created.0.1.2"
+          "default": "dev.cdevents.change.created.0.2.0"
         },
         "timestamp": {
           "type": "string",
@@ -60,6 +60,10 @@
         },
         "content": {
           "properties": {
+            "description": {
+              "type": "string",
+              "minLength": 1
+            },
             "repository": {
               "properties": {
                 "id": {

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -58,6 +58,7 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
 | type | `String` | See [type](spec.md#type-subject) | `change` |
+| description | `String` | Description associated with the change, e.g. A pull request's description | `This PR addresses a fix for some feature`|
 | repository | `Object` ([`repository`](#repository)) | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ## Events
@@ -148,7 +149,7 @@ A branch inside the Repository was deleted.
 
 A source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit.
 
-- Event Type: __`dev.cdevents.change.created.0.1.2`__
+- Event Type: __`dev.cdevents.change.created.0.2.0`__
 - Predicate: created
 - Subject: [`change`](#change)
 
@@ -157,6 +158,7 @@ A source code change was created and submitted to a repository specific branch. 
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
 | type | `String` | See [type](spec.md#type-subject) | `change` | |
+| description | `String` | Description associated with the change, e.g. A pull request's description | `This PR addresses a fix for some feature`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### [`change reviewed`](examples/change_reviewed.json)


### PR DESCRIPTION
# Changes

This commit adds a new optional field to the dev.cdevents.change.created
event.  This field, description, should be used to describe the change,
e.g. a GitHub PR.

An example of the description field could be something like

"This PR addresses a new bug that was introduced in some PR"

resolves #151

Signed-off-by: benjamin-j-powell <benjamin_j_powell@apple.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/spec/blob/main/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/tektoncd/community/blob/main/standards.md#tests) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://github.com/cdevents/spec/blob/main/primer/_index.md#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)