### PR TITLE
Update pipelinequeuerequested.json to use uri instead of url

### DIFF
--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -63,7 +63,7 @@
             "pipelineName": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string"
             }
           },


### PR DESCRIPTION

# Changes

The pipelineququerequested schema uses the field uri instead of url. This is different from the two other pipeline schemas and different from the markdown docs for the schema.

This is related to the following issue: https://github.com/cdevents/spec/issues/160
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [X] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [X] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [X] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
