### PR TITLE
Update testsuiterunqueued.json to replace url with uri

### DIFF
--- a/examples/testsuiterun_queued.json
+++ b/examples/testsuiterun_queued.json
@@ -3,7 +3,7 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testsuiterun.queued.0.1.0",
+    "type": "dev.cdevents.testsuiterun.queued.0.4.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z"
   },
   "subject": {

--- a/examples/testsuiterun_queued.json
+++ b/examples/testsuiterun_queued.json
@@ -3,7 +3,7 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testsuiterun.queued.0.4.0-draft",
+    "type": "dev.cdevents.testsuiterun.queued.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z"
   },
   "subject": {

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -19,9 +19,9 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuiterun.queued.0.1.0"
+            "dev.cdevents.testsuiterun.queued.0.4.0-draft"
           ],
-          "default": "dev.cdevents.testsuiterun.queued.0.1.0"
+          "default": "dev.cdevents.testsuiterun.queued.0.4.0-draft"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -111,7 +111,7 @@
                 "name": {
                   "type": "string"
                 },
-                "url": {
+                "uri": {
                   "type": "string",
                   "format": "uri"
                 }

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -19,9 +19,9 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuiterun.queued.0.4.0-draft"
+            "dev.cdevents.testsuiterun.queued.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testsuiterun.queued.0.4.0-draft"
+          "default": "dev.cdevents.testsuiterun.queued.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",


### PR DESCRIPTION
# Changes
The testsuiterunqueued schema uses the field url under testsuite. Within the other testsuite run schemas, uri is used. This is also used in the markdown documents.

This change updates the testsuiterunqueued schema to bring it in line with the other testsuite's

This is in relation to: https://github.com/cdevents/spec/issues/160
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [X] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [X] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [X] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
