### PR TITLE
Add outcome to buildfinished event

### DIFF
--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -80,7 +80,7 @@ This event represents a Build task that has been started; this build process usu
 
 ### [`build finished`](examples/build_finished.json)
 
-This event represents a Build task that has finished. This event will eventually contain the finished status, success, error or failure
+This event represents a Build task that has finished and will contain the outcome of the given build.
 
 - Event Type: __`dev.cdevents.build.finished.0.1.1`__
 - Predicate: finished
@@ -92,6 +92,7 @@ This event represents a Build task that has finished. This event will eventually
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
 | type | `String` | See [type](spec.md#type-subject) | |
 | artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | `build` | |
+| outcome | `String` | Represents the finished state of a build. | `succeeded`, `failed`, `cancelled` | |
 
 ### [`artifact packaged`](examples/artifact_packaged.json)
 

--- a/examples/build_finished.json
+++ b/examples/build_finished.json
@@ -3,7 +3,7 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.build.finished.0.1.1",
+    "type": "dev.cdevents.build.finished.0.1.2",
     "timestamp": "2023-03-20T14:27:05.315384Z"
   },
   "subject": {
@@ -11,7 +11,8 @@
     "source": "/event/source/123",
     "type": "build",
     "content": {
-      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427"
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "outcome": "succeeded"
     }
   }
 }

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -20,9 +20,9 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.finished.0.1.1"
+            "dev.cdevents.build.finished.0.1.2"
           ],
-          "default": "dev.cdevents.build.finished.0.1.1"
+          "default": "dev.cdevents.build.finished.0.1.2"
         },
         "timestamp": {
           "type": "string",
@@ -62,6 +62,15 @@
           "properties": {
             "artifactId": {
               "type": "string"
+            },
+            "outcome": {
+              "type": "string",
+              "minLength": 1,
+              "enum": [
+                "succeeded",
+                "failed",
+                "cancelled"
+              ]
             }
           },
           "additionalProperties": false,

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -20,9 +20,9 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.finished.0.1.2"
+            "dev.cdevents.build.finished.0.1.2-draft"
           ],
-          "default": "dev.cdevents.build.finished.0.1.2"
+          "default": "dev.cdevents.build.finished.0.1.2-draft"
         },
         "timestamp": {
           "type": "string",

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -67,7 +67,13 @@
               "type": "string"
             },
             "outcome": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1,
+              "enum": [
+                "passed",
+                "failed",
+                "cancelled"
+              ]
             },
             "errors": {
               "type": "string"

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -85,7 +85,12 @@
               ]
             },
             "outcome": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "succeeded",
+                "failed",
+                "cancelled"
+              ]
             },
             "errors": {
               "type": "string"

--- a/schemas/testcaserunfinished.json
+++ b/schemas/testcaserunfinished.json
@@ -60,10 +60,9 @@
             "outcome": {
               "type": "string",
               "enum": [
-                "pass",
-                "fail",
-                "cancel",
-                "error"
+                "passed",
+                "failed",
+                "cancelled"
               ]
             },
             "severity": {

--- a/schemas/testsuiterunfinished.json
+++ b/schemas/testsuiterunfinished.json
@@ -100,11 +100,11 @@
             },
             "outcome": {
               "type": "string",
+              "minLength": 1,
               "enum": [
-                "pass",
-                "fail",
-                "cancel",
-                "error"
+                "passed",
+                "failed",
+                "cancelled"
               ]
             },
             "severity": {


### PR DESCRIPTION
# Changes

This PR addresses a missing field of, `outcome`, that should exist in the `build.finished` event.

This follows the `outcome` of `taskRun.finished`, except that it utilizes an enum value instead. Users should be able to pass any string they want to, but we should also have some sane enums so consumers and producers do not have several ways of representing the same thing.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
