### PR TITLE
Fix the event example in cloudevents-binding

### DIFF
--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -92,7 +92,7 @@ Full example of a CDEvents transported through a CloudEvent in HTTP *binary* mod
 POST /sink HTTP/1.1
 Host: cdevents.example.com
 ce-specversion: 1.0
-ce-type: dev.cdevents.taskrun.started.0.1-draft
+ce-type: dev.cdevents.taskrun.started.0.1.1
 ce-time: 2018-04-05T17:31:00Z
 ce-id: A234-1234-1234
 ce-source: /staging/tekton/
@@ -102,10 +102,10 @@ Content-Length: nnnn
 
 {
    "context": {
-      "version": "0.4.0-draft",
+      "version": "0.3.0",
       "id" : "A234-1234-1234",
       "source" : "/staging/tekton/",
-      "type" : "dev.cdevents.taskrun.started",
+      "type" : "dev.cdevents.taskrun.started.0.1.1",
       "timestamp" : "2018-04-05T17:31:00Z",
    }
    "subject" : {


### PR DESCRIPTION

# Changes

The current example uses an incosistent type and draft versions. Align the example with the v0.3.0 spec and make it consistent.

Fixes: #178

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
