### PR TITLE
Add an optional schemaUri to the context

### DIFF
--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -51,7 +51,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 This event represents an environment that has been created. Such an environment can be used to deploy services in.
 
-- Event Type: __`dev.cdevents.environment.created.0.1.1`__
+- Event Type: __`dev.cdevents.environment.created.0.2.0-draft`__
 - Predicate: created
 - Subject: [`environment`](#environment)
 
@@ -67,7 +67,7 @@ This event represents an environment that has been created. Such an environment 
 
 This event represents an environment that has been modified.
 
-- Event Type: __`dev.cdevents.environment.modified.0.1.1`__
+- Event Type: __`dev.cdevents.environment.modified.0.2.0-draft`__
 - Predicate: modified
 - Subject: [`environment`](#environment)
 
@@ -83,7 +83,7 @@ This event represents an environment that has been modified.
 
 This event represents an environment that has been deleted.```
 
-- Event Type: __`dev.cdevents.environment.deleted.0.1.1`__
+- Event Type: __`dev.cdevents.environment.deleted.0.2.0-draft`__
 - Predicate: deleted
 - Subject: [`environment`](#environment)
 
@@ -98,7 +98,7 @@ This event represents an environment that has been deleted.```
 
 This event represents a new instance of a service that has been deployed
 
-- Event Type: __`dev.cdevents.service.deployed.0.1.1`__
+- Event Type: __`dev.cdevents.service.deployed.0.2.0-draft`__
 - Predicate: deployed
 - Subject: [`service`](#service)
 
@@ -114,7 +114,7 @@ This event represents a new instance of a service that has been deployed
 
 This event represents an existing instance of a service that has been upgraded to a new version
 
-- Event Type: __`dev.cdevents.service.upgraded.0.1.1`__
+- Event Type: __`dev.cdevents.service.upgraded.0.2.0-draft`__
 - Predicate: upgraded
 - Subject: [`service`](#service)
 
@@ -130,7 +130,7 @@ This event represents an existing instance of a service that has been upgraded t
 
 This event represents an existing instance of a service that has been rolled back to a previous version
 
-- Event Type: __`dev.cdevents.service.rolledback.0.1.1`__
+- Event Type: __`dev.cdevents.service.rolledback.0.2.0-draft`__
 - Predicate: rolledback
 - Subject: [`service`](#service)
 
@@ -146,7 +146,7 @@ This event represents an existing instance of a service that has been rolled bac
 
 This event represents the removal of a previously deployed service instance and is thus not longer present in the specified environment
 
-- Event Type: __`dev.cdevents.service.removed.0.1.1`__
+- Event Type: __`dev.cdevents.service.removed.0.2.0-draft`__
 - Predicate: removed
 - Subject: [`service`](#service)
 
@@ -161,7 +161,7 @@ This event represents the removal of a previously deployed service instance and 
 
 This event represents an existing instance of a service that has an accessible URL for users to interact with it. This event can be used to let other tools know that the service is ready and also available for consumption.
 
-- Event Type: __`dev.cdevents.service.published.0.1.1`__
+- Event Type: __`dev.cdevents.service.published.0.2.0-draft`__
 - Predicate: published
 - Subject: [`service`](#service)
 

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -56,7 +56,7 @@ An `artifact` is usually produced as output of a build process. Events need to b
 
 This event represents a Build task that has been queued; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.queued.0.1.1`__
+- Event Type: __`dev.cdevents.build.queued.0.2.0-draft`__
 - Predicate: queued
 - Subject: [`build`](#build)
 
@@ -70,7 +70,7 @@ This event represents a Build task that has been queued; this build process usua
 
 This event represents a Build task that has been started; this build process usually is in charge of producing a binary from source code.
 
-- Event Type: __`dev.cdevents.build.started.0.1.1`__
+- Event Type: __`dev.cdevents.build.started.0.2.0-draft`__
 - Predicate: started
 - Subject: [`build`](#build)
 
@@ -84,7 +84,7 @@ This event represents a Build task that has been started; this build process usu
 
 This event represents a Build task that has finished. This event will eventually contain the finished status, success, error or failure
 
-- Event Type: __`dev.cdevents.build.finished.0.1.1`__
+- Event Type: __`dev.cdevents.build.finished.0.2.0-draft`__
 - Predicate: finished
 - Subject: [`build`](#build)
 
@@ -117,7 +117,7 @@ This event is usually produced by the build system. If an SBOM URI is available 
 The event represents an artifact that has been signed. The signature is included in the events itself.
 An artifact may be signed after it has been packaged or sometimes after it has published, depending on the tooling being used and the type of artifact. The `artifact signed` event is typically produced by the CI or build system.
 
-- Event Type: __`dev.cdevents.artifact.signed.0.1.0`__
+- Event Type: __`dev.cdevents.artifact.signed.0.2.0-draft`__
 - Predicate: signed
 - Subject: [`artifact`](#artifact)
 

--- a/continuous-operations.md
+++ b/continuous-operations.md
@@ -40,7 +40,7 @@ An `incident` represents a problem in a production environment.
 
 This event represents an incident that has been detected by a system or human.
 
-- Event Type: __`dev.cdevents.incident.detected.0.1.0`__
+- Event Type: __`dev.cdevents.incident.detected.0.2.0-draft`__
 - Predicate: detected
 - Subject: [`incident`](#incident)
 
@@ -58,7 +58,7 @@ This event represents an incident that has been detected by a system or human.
 
 This event represents an incident that has been reported through a ticketing system. Compared to the `detected` predicated, it introduces a ticket URI.
 
-- Event Type: __`dev.cdevents.incident.reported.0.1.0`__
+- Event Type: __`dev.cdevents.incident.reported.0.2.0-draft`__
 - Predicate: reported
 - Subject: [`incident`](#incident)
 
@@ -77,7 +77,7 @@ This event represents an incident that has been reported through a ticketing sys
 
 This event represents an incident that has been resolved, meaning that the problem identified by the incident has been solved or recalled.
 
-- Event Type: __`dev.cdevents.incident.resolved.0.1.0`__
+- Event Type: __`dev.cdevents.incident.resolved.0.2.0-draft`__
 - Predicate: resolved
 - Subject: [`incident`](#incident)
 

--- a/core.md
+++ b/core.md
@@ -68,7 +68,7 @@ Due the dynamic nature of Pipelines, most of actual work needs to be queued to
 happen in a distributed way, hence queued events are added. Adopters can choose
 to ignore these events if they don't apply to their use cases.
 
-- Event Type: __`dev.cdevents.pipelinerun.queued.0.1.1`__
+- Event Type: __`dev.cdevents.pipelinerun.queued.0.2.0-draft`__
 - Predicate: queued
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -84,7 +84,7 @@ to ignore these events if they don't apply to their use cases.
 
 A pipelineRun has started and it is running.
 
-- Event Type: __`dev.cdevents.pipelinerun.started.0.1.1`__
+- Event Type: __`dev.cdevents.pipelinerun.started.0.2.0-draft`__
 - Predicate: started
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -100,7 +100,7 @@ A pipelineRun has started and it is running.
 
 A pipelineRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.pipelinerun.finished.0.1.1`__
+- Event Type: __`dev.cdevents.pipelinerun.finished.0.2.0-draft`__
 - Predicate: finished
 - Subject: [`pipelineRun`](#pipelinerun)
 
@@ -118,7 +118,7 @@ A pipelineRun has finished, successfully or not.
 
 A taskRun has started and it is running.
 
-- Event Type: __`dev.cdevents.taskrun.started.0.1.1`__
+- Event Type: __`dev.cdevents.taskrun.started.0.2.0-draft`__
 - Predicate: started
 - Subject: [`taskRun`](#taskrun)
 
@@ -135,7 +135,7 @@ A taskRun has started and it is running.
 
 A taskRun has finished, successfully or not.
 
-- Event Type: __`dev.cdevents.taskrun.finished.0.1.1`__
+- Event Type: __`dev.cdevents.taskrun.finished.0.2.0-draft`__
 - Predicate: finished
 - Subject: [`taskRun`](#taskrun)
 

--- a/examples/artifact_deleted.json
+++ b/examples/artifact_deleted.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.deleted.0.1.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_deleted.json
+++ b/examples/artifact_deleted.json
@@ -4,7 +4,8 @@
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.deleted.0.1.0-draft",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_downloaded.json
+++ b/examples/artifact_downloaded.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.downloaded.0.1.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_downloaded.json
+++ b/examples/artifact_downloaded.json
@@ -4,7 +4,8 @@
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.downloaded.0.1.0-draft",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_packaged.json
+++ b/examples/artifact_packaged.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.packaged.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_packaged.json
+++ b/examples/artifact_packaged.json
@@ -4,7 +4,8 @@
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.packaged.0.2.0-draft",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_published.json
+++ b/examples/artifact_published.json
@@ -4,7 +4,8 @@
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.published.0.2.0-draft",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_published.json
+++ b/examples/artifact_published.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.published.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_signed.json
+++ b/examples/artifact_signed.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.artifact.signed.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.artifact.signed.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/artifact_signed.json
+++ b/examples/artifact_signed.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.artifact.signed.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",

--- a/examples/branch_created.json
+++ b/examples/branch_created.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.branch.created.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/branch_created.json
+++ b/examples/branch_created.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.branch.created.0.1.2",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.branch.created.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/branch_deleted.json
+++ b/examples/branch_deleted.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.branch.deleted.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/branch_deleted.json
+++ b/examples/branch_deleted.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.branch.deleted.0.1.2",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.branch.deleted.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/build_finished.json
+++ b/examples/build_finished.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.build.finished.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/build_finished.json
+++ b/examples/build_finished.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.build.finished.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.build.finished.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/build_queued.json
+++ b/examples/build_queued.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.build.queued.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/build_queued.json
+++ b/examples/build_queued.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.build.queued.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.build.queued.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/build_started.json
+++ b/examples/build_started.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.build.started.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.build.started.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/build_started.json
+++ b/examples/build_started.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.build.started.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_abandoned.json
+++ b/examples/change_abandoned.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.change.abandoned.0.1.2",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.change.abandoned.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_abandoned.json
+++ b/examples/change_abandoned.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.change.abandoned.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_created.json
+++ b/examples/change_created.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.change.created.0.3.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_created.json
+++ b/examples/change_created.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.change.created.0.2.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.change.created.0.3.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_merged.json
+++ b/examples/change_merged.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.change.merged.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_merged.json
+++ b/examples/change_merged.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.change.merged.0.1.2",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.change.merged.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_reviewed.json
+++ b/examples/change_reviewed.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.change.reviewed.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_reviewed.json
+++ b/examples/change_reviewed.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.change.reviewed.0.1.2",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.change.reviewed.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_updated.json
+++ b/examples/change_updated.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.change.updated.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/change_updated.json
+++ b/examples/change_updated.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.change.updated.0.1.2",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.change.updated.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/environment_created.json
+++ b/examples/environment_created.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.environment.created.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/environment_created.json
+++ b/examples/environment_created.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.environment.created.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.environment.created.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/environment_deleted.json
+++ b/examples/environment_deleted.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.environment.deleted.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/environment_deleted.json
+++ b/examples/environment_deleted.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.environment.deleted.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.environment.deleted.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/environment_modified.json
+++ b/examples/environment_modified.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.environment.modified.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/environment_modified.json
+++ b/examples/environment_modified.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.environment.modified.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.environment.modified.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/incident_detected.json
+++ b/examples/incident_detected.json
@@ -3,7 +3,7 @@
       "version": "0.4.0-draft",
       "id": "F4BD2B55-B6F6-4F44-AF72-BD2D0E7A8708",
       "source": "/monitoring/prod1",
-      "type": "dev.cdevents.incident.detected.0.1.0",
+      "type": "dev.cdevents.incident.detected.0.2.0-draft",
       "timestamp": "2022-11-11T13:52:20.079Z"
   },
   "subject": {

--- a/examples/incident_reported.json
+++ b/examples/incident_reported.json
@@ -3,7 +3,7 @@
       "version": "0.4.0-draft",
       "id": "F4BD2B55-B6F6-4F44-AF72-BD2D0E7A8708",
       "source": "/monitoring/prod1",
-      "type": "dev.cdevents.incident.reported.0.1.0",
+      "type": "dev.cdevents.incident.reported.0.2.0-draft",
       "timestamp": "2022-11-11T13:52:20.079Z"
   },
   "subject": {

--- a/examples/incident_resolved.json
+++ b/examples/incident_resolved.json
@@ -3,7 +3,7 @@
       "version": "0.4.0-draft",
       "id": "F4BD2B55-B6F6-4F44-AF72-BD2D0E7A8708",
       "source": "/monitoring/prod1",
-      "type": "dev.cdevents.incident.resolved.0.1.0",
+      "type": "dev.cdevents.incident.resolved.0.2.0-draft",
       "timestamp": "2022-11-11T13:52:20.079Z"
   },
   "subject": {

--- a/examples/pipelinerun_finished.json
+++ b/examples/pipelinerun_finished.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.pipelinerun.finished.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/pipelinerun_finished.json
+++ b/examples/pipelinerun_finished.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.pipelinerun.finished.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.pipelinerun.finished.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/pipelinerun_queued.json
+++ b/examples/pipelinerun_queued.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.pipelinerun.queued.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/pipelinerun_queued.json
+++ b/examples/pipelinerun_queued.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.pipelinerun.queued.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.pipelinerun.queued.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/pipelinerun_started.json
+++ b/examples/pipelinerun_started.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.pipelinerun.started.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.pipelinerun.started.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/pipelinerun_started.json
+++ b/examples/pipelinerun_started.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.pipelinerun.started.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/repository_created.json
+++ b/examples/repository_created.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.repository.created.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/repository_created.json
+++ b/examples/repository_created.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.repository.created.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.repository.created.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/repository_deleted.json
+++ b/examples/repository_deleted.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.repository.deleted.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/repository_deleted.json
+++ b/examples/repository_deleted.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.repository.deleted.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.repository.deleted.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/repository_modified.json
+++ b/examples/repository_modified.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.repository.modified.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/repository_modified.json
+++ b/examples/repository_modified.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.repository.modified.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.repository.modified.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_deployed.json
+++ b/examples/service_deployed.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.service.deployed.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_deployed.json
+++ b/examples/service_deployed.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.service.deployed.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.service.deployed.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_published.json
+++ b/examples/service_published.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.service.published.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.service.published.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_published.json
+++ b/examples/service_published.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.service.published.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_removed.json
+++ b/examples/service_removed.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.service.removed.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_removed.json
+++ b/examples/service_removed.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.service.removed.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.service.removed.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_rolledback.json
+++ b/examples/service_rolledback.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.service.rolledback.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_rolledback.json
+++ b/examples/service_rolledback.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.service.rolledback.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.service.rolledback.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_upgraded.json
+++ b/examples/service_upgraded.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.service.upgraded.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.service.upgraded.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/service_upgraded.json
+++ b/examples/service_upgraded.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.service.upgraded.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/taskrun_finished.json
+++ b/examples/taskrun_finished.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.taskrun.finished.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/taskrun_finished.json
+++ b/examples/taskrun_finished.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.taskrun.finished.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.taskrun.finished.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/taskrun_started.json
+++ b/examples/taskrun_started.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.taskrun.started.0.1.1",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.taskrun.started.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/taskrun_started.json
+++ b/examples/taskrun_started.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.taskrun.started.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "mySubject123",

--- a/examples/testcaserun_finished.json
+++ b/examples/testcaserun_finished.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testcaserun.finished.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestCaseRun123",

--- a/examples/testcaserun_finished.json
+++ b/examples/testcaserun_finished.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testcaserun.finished.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testcaserun.finished.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestCaseRun123",

--- a/examples/testcaserun_queued.json
+++ b/examples/testcaserun_queued.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testcaserun.queued.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testcaserun.queued.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestCaseRun123",

--- a/examples/testcaserun_queued.json
+++ b/examples/testcaserun_queued.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testcaserun.queued.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestCaseRun123",

--- a/examples/testcaserun_started.json
+++ b/examples/testcaserun_started.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testcaserun.started.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testcaserun.started.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestCaseRun123",

--- a/examples/testcaserun_started.json
+++ b/examples/testcaserun_started.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testcaserun.started.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestCaseRun123",

--- a/examples/testoutput_published.json
+++ b/examples/testoutput_published.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testoutput.published.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "testrunreport-12123",

--- a/examples/testoutput_published.json
+++ b/examples/testoutput_published.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testoutput.published.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testoutput.published.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "testrunreport-12123",

--- a/examples/testsuiterun_finished.json
+++ b/examples/testsuiterun_finished.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testsuiterun.finished.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testsuiterun.finished.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestSuiteRun123",

--- a/examples/testsuiterun_finished.json
+++ b/examples/testsuiterun_finished.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testsuiterun.finished.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestSuiteRun123",

--- a/examples/testsuiterun_queued.json
+++ b/examples/testsuiterun_queued.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testsuiterun.queued.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestSuiteRun123",

--- a/examples/testsuiterun_queued.json
+++ b/examples/testsuiterun_queued.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testsuiterun.queued.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testsuiterun.queued.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestSuiteRun123",

--- a/examples/testsuiterun_started.json
+++ b/examples/testsuiterun_started.json
@@ -3,8 +3,9 @@
     "version": "0.4.0-draft",
     "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
     "source": "/event/source/123",
-    "type": "dev.cdevents.testsuiterun.started.0.1.0",
-    "timestamp": "2023-03-20T14:27:05.315384Z"
+    "type": "dev.cdevents.testsuiterun.started.0.2.0-draft",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaURI": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestSuiteRun123",

--- a/examples/testsuiterun_started.json
+++ b/examples/testsuiterun_started.json
@@ -5,7 +5,7 @@
     "source": "/event/source/123",
     "type": "dev.cdevents.testsuiterun.started.0.2.0-draft",
     "timestamp": "2023-03-20T14:27:05.315384Z",
-    "schemaURI": "https://myorg.com/schema/custom"
+    "schemaUri": "https://myorg.com/schema/custom"
   },
   "subject": {
     "id": "myTestSuiteRun123",

--- a/schemas/artifactdeleted.json
+++ b/schemas/artifactdeleted.json
@@ -27,6 +27,11 @@
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/artifactdeleted.json
+++ b/schemas/artifactdeleted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/artifactdownloaded.json
+++ b/schemas/artifactdownloaded.json
@@ -27,6 +27,11 @@
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/artifactdownloaded.json
+++ b/schemas/artifactdownloaded.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -27,6 +27,11 @@
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -27,6 +27,11 @@
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/artifactsigned.json
+++ b/schemas/artifactsigned.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/artifactsigned.json
+++ b/schemas/artifactsigned.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.artifact.signed.0.1.0"
+            "dev.cdevents.artifact.signed.0.2.0-draft"
           ],
-          "default": "dev.cdevents.artifact.signed.0.1.0"
+          "default": "dev.cdevents.artifact.signed.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.branch.created.0.1.2"
+            "dev.cdevents.branch.created.0.2.0-draft"
           ],
-          "default": "dev.cdevents.branch.created.0.1.2"
+          "default": "dev.cdevents.branch.created.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.branch.deleted.0.1.2"
+            "dev.cdevents.branch.deleted.0.2.0-draft"
           ],
-          "default": "dev.cdevents.branch.deleted.0.1.2"
+          "default": "dev.cdevents.branch.deleted.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.finished.0.1.1"
+            "dev.cdevents.build.finished.0.2.0-draft"
           ],
-          "default": "dev.cdevents.build.finished.0.1.1"
+          "default": "dev.cdevents.build.finished.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.queued.0.1.1"
+            "dev.cdevents.build.queued.0.2.0-draft"
           ],
-          "default": "dev.cdevents.build.queued.0.1.1"
+          "default": "dev.cdevents.build.queued.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.build.started.0.1.1"
+            "dev.cdevents.build.started.0.2.0-draft"
           ],
-          "default": "dev.cdevents.build.started.0.1.1"
+          "default": "dev.cdevents.build.started.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.abandoned.0.1.2"
+            "dev.cdevents.change.abandoned.0.2.0-draft"
           ],
-          "default": "dev.cdevents.change.abandoned.0.1.2"
+          "default": "dev.cdevents.change.abandoned.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.created.0.2.0"
+            "dev.cdevents.change.created.0.3.0-draft"
           ],
-          "default": "dev.cdevents.change.created.0.2.0"
+          "default": "dev.cdevents.change.created.0.3.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.merged.0.1.2"
+            "dev.cdevents.change.merged.0.2.0-draft"
           ],
-          "default": "dev.cdevents.change.merged.0.1.2"
+          "default": "dev.cdevents.change.merged.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.reviewed.0.1.2"
+            "dev.cdevents.change.reviewed.0.2.0-draft"
           ],
-          "default": "dev.cdevents.change.reviewed.0.1.2"
+          "default": "dev.cdevents.change.reviewed.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.change.updated.0.1.2"
+            "dev.cdevents.change.updated.0.2.0-draft"
           ],
-          "default": "dev.cdevents.change.updated.0.1.2"
+          "default": "dev.cdevents.change.updated.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.environment.created.0.1.1"
+            "dev.cdevents.environment.created.0.2.0-draft"
           ],
-          "default": "dev.cdevents.environment.created.0.1.1"
+          "default": "dev.cdevents.environment.created.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.environment.deleted.0.1.1"
+            "dev.cdevents.environment.deleted.0.2.0-draft"
           ],
-          "default": "dev.cdevents.environment.deleted.0.1.1"
+          "default": "dev.cdevents.environment.deleted.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.environment.modified.0.1.1"
+            "dev.cdevents.environment.modified.0.2.0-draft"
           ],
-          "default": "dev.cdevents.environment.modified.0.1.1"
+          "default": "dev.cdevents.environment.modified.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.incident.detected.0.1.0"
+            "dev.cdevents.incident.detected.0.2.0-draft"
           ],
-          "default": "dev.cdevents.incident.detected.0.1.0"
+          "default": "dev.cdevents.incident.detected.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.incident.reported.0.1.0"
+            "dev.cdevents.incident.reported.0.2.0-draft"
           ],
-          "default": "dev.cdevents.incident.reported.0.1.0"
+          "default": "dev.cdevents.incident.reported.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.incident.resolved.0.1.0"
+            "dev.cdevents.incident.resolved.0.2.0-draft"
           ],
-          "default": "dev.cdevents.incident.resolved.0.1.0"
+          "default": "dev.cdevents.incident.resolved.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.pipelinerun.finished.0.1.1"
+            "dev.cdevents.pipelinerun.finished.0.2.0-draft"
           ],
-          "default": "dev.cdevents.pipelinerun.finished.0.1.1"
+          "default": "dev.cdevents.pipelinerun.finished.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.pipelinerun.queued.0.1.1"
+            "dev.cdevents.pipelinerun.queued.0.2.0-draft"
           ],
-          "default": "dev.cdevents.pipelinerun.queued.0.1.1"
+          "default": "dev.cdevents.pipelinerun.queued.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.pipelinerun.started.0.1.1"
+            "dev.cdevents.pipelinerun.started.0.2.0-draft"
           ],
-          "default": "dev.cdevents.pipelinerun.started.0.1.1"
+          "default": "dev.cdevents.pipelinerun.started.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.repository.created.0.1.1"
+            "dev.cdevents.repository.created.0.2.0-draft"
           ],
-          "default": "dev.cdevents.repository.created.0.1.1"
+          "default": "dev.cdevents.repository.created.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.repository.deleted.0.1.1"
+            "dev.cdevents.repository.deleted.0.2.0-draft"
           ],
-          "default": "dev.cdevents.repository.deleted.0.1.1"
+          "default": "dev.cdevents.repository.deleted.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.repository.modified.0.1.1"
+            "dev.cdevents.repository.modified.0.2.0-draft"
           ],
-          "default": "dev.cdevents.repository.modified.0.1.1"
+          "default": "dev.cdevents.repository.modified.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.deployed.0.1.1"
+            "dev.cdevents.service.deployed.0.2.0-draft"
           ],
-          "default": "dev.cdevents.service.deployed.0.1.1"
+          "default": "dev.cdevents.service.deployed.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.published.0.1.1"
+            "dev.cdevents.service.published.0.2.0-draft"
           ],
-          "default": "dev.cdevents.service.published.0.1.1"
+          "default": "dev.cdevents.service.published.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.removed.0.1.1"
+            "dev.cdevents.service.removed.0.2.0-draft"
           ],
-          "default": "dev.cdevents.service.removed.0.1.1"
+          "default": "dev.cdevents.service.removed.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.rolledback.0.1.1"
+            "dev.cdevents.service.rolledback.0.2.0-draft"
           ],
-          "default": "dev.cdevents.service.rolledback.0.1.1"
+          "default": "dev.cdevents.service.rolledback.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.service.upgraded.0.1.1"
+            "dev.cdevents.service.upgraded.0.2.0-draft"
           ],
-          "default": "dev.cdevents.service.upgraded.0.1.1"
+          "default": "dev.cdevents.service.upgraded.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.taskrun.finished.0.1.1"
+            "dev.cdevents.taskrun.finished.0.2.0-draft"
           ],
-          "default": "dev.cdevents.taskrun.finished.0.1.1"
+          "default": "dev.cdevents.taskrun.finished.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -28,7 +28,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -20,13 +20,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.taskrun.started.0.1.1"
+            "dev.cdevents.taskrun.started.0.2.0-draft"
           ],
-          "default": "dev.cdevents.taskrun.started.0.1.1"
+          "default": "dev.cdevents.taskrun.started.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testcaserunfinished.json
+++ b/schemas/testcaserunfinished.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testcaserun.finished.0.1.0"
+            "dev.cdevents.testcaserun.finished.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testcaserun.finished.0.1.0"
+          "default": "dev.cdevents.testcaserun.finished.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testcaserunfinished.json
+++ b/schemas/testcaserunfinished.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testcaserunqueued.json
+++ b/schemas/testcaserunqueued.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testcaserunqueued.json
+++ b/schemas/testcaserunqueued.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testcaserun.queued.0.1.0"
+            "dev.cdevents.testcaserun.queued.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testcaserun.queued.0.1.0"
+          "default": "dev.cdevents.testcaserun.queued.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testcaserunstarted.json
+++ b/schemas/testcaserunstarted.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testcaserun.started.0.1.0"
+            "dev.cdevents.testcaserun.started.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testcaserun.started.0.1.0"
+          "default": "dev.cdevents.testcaserun.started.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testcaserunstarted.json
+++ b/schemas/testcaserunstarted.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testoutputpublished.json
+++ b/schemas/testoutputpublished.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testoutputpublished.json
+++ b/schemas/testoutputpublished.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testoutput.published.0.1.0"
+            "dev.cdevents.testoutput.published.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testoutput.published.0.1.0"
+          "default": "dev.cdevents.testoutput.published.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testsuiterunfinished.json
+++ b/schemas/testsuiterunfinished.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testsuiterunfinished.json
+++ b/schemas/testsuiterunfinished.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuiterun.finished.0.1.0"
+            "dev.cdevents.testsuiterun.finished.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testsuiterun.finished.0.1.0"
+          "default": "dev.cdevents.testsuiterun.finished.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuiterun.queued.0.1.0"
+            "dev.cdevents.testsuiterun.queued.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testsuiterun.queued.0.1.0"
+          "default": "dev.cdevents.testsuiterun.queued.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/schemas/testsuiterunstarted.json
+++ b/schemas/testsuiterunstarted.json
@@ -27,7 +27,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "schemaURI": {
+        "schemaUri": {
           "type": "string",
           "minLength": 1,
           "format": "uri"

--- a/schemas/testsuiterunstarted.json
+++ b/schemas/testsuiterunstarted.json
@@ -19,13 +19,18 @@
         "type": {
           "type": "string",
           "enum": [
-            "dev.cdevents.testsuiterun.started.0.1.0"
+            "dev.cdevents.testsuiterun.started.0.2.0-draft"
           ],
-          "default": "dev.cdevents.testsuiterun.started.0.1.0"
+          "default": "dev.cdevents.testsuiterun.started.0.2.0-draft"
         },
         "timestamp": {
           "type": "string",
           "format": "date-time"
+        },
+        "schemaURI": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
         }
       },
       "additionalProperties": false,

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -67,7 +67,7 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 
 A new Source Code Repository was created to host source code for a project.
 
-- Event Type: __`dev.cdevents.repository.created.0.1.1`__
+- Event Type: __`dev.cdevents.repository.created.0.2.0-draft`__
 - Predicate: created
 - Subject: [`repository`](#repository)
 
@@ -85,7 +85,7 @@ A new Source Code Repository was created to host source code for a project.
 
 A Source Code Repository modified some of its attributes, like location, or owner.
 
-- Event Type: __`dev.cdevents.repository.modified.0.1.1`__
+- Event Type: __`dev.cdevents.repository.modified.0.2.0-draft`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -101,7 +101,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 ### [`repository deleted`](examples/repository_deleted.json)
 
-- Event Type: __`dev.cdevents.repository.deleted.0.1.1`__
+- Event Type: __`dev.cdevents.repository.deleted.0.2.0-draft`__
 - Predicate: modified
 - Subject: [`repository`](#repository)
 
@@ -119,7 +119,7 @@ A Source Code Repository modified some of its attributes, like location, or owne
 
 A branch inside the Repository was created.
 
-- Event Type: __`dev.cdevents.branch.created.0.1.2`__
+- Event Type: __`dev.cdevents.branch.created.0.2.0-draft`__
 - Predicate: created
 - Subject: [`branch`](#branch)
 
@@ -134,7 +134,7 @@ A branch inside the Repository was created.
 
 A branch inside the Repository was deleted.
 
-- Event Type: __`dev.cdevents.branch.deleted.0.1.2`__
+- Event Type: __`dev.cdevents.branch.deleted.0.2.0-draft`__
 - Predicate: deleted
 - Subject: [`branch`](#branch)
 
@@ -149,7 +149,7 @@ A branch inside the Repository was deleted.
 
 A source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit.
 
-- Event Type: __`dev.cdevents.change.created.0.2.0`__
+- Event Type: __`dev.cdevents.change.created.0.3.0-draft`__
 - Predicate: created
 - Subject: [`change`](#change)
 
@@ -165,7 +165,7 @@ A source code change was created and submitted to a repository specific branch. 
 
 Someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.
 
-- Event Type: __`dev.cdevents.change.reviewed.0.1.2`__
+- Event Type: __`dev.cdevents.change.reviewed.0.2.0-draft`__
 - Predicate: reviewed
 - Subject: [`change`](#change)
 
@@ -180,7 +180,7 @@ Someone (user) or an automated system submitted an review to the source code cha
 
 A change is merged to the target branch where it was submitted.
 
-- Event Type: __`dev.cdevents.change.merged.0.1.2`__
+- Event Type: __`dev.cdevents.change.merged.0.2.0-draft`__
 - Predicate: merged
 - Subject: [`change`](#change)
 
@@ -195,7 +195,7 @@ A change is merged to the target branch where it was submitted.
 
 A tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
 
-- Event Type: __`dev.cdevents.change.abandoned.0.1.2`__
+- Event Type: __`dev.cdevents.change.abandoned.0.2.0-draft`__
 - Predicate: abandoned
 - Subject: [`change`](#change)
 
@@ -210,7 +210,7 @@ A tool or a user decides that the change has been inactive for a while and it ca
 
 A Change has been updated, for example a new commit is added or removed from an existing Change.
 
-- Event Type: __`dev.cdevents.change.updated.0.1.2`__
+- Event Type: __`dev.cdevents.change.updated.0.2.0-draft`__
 - Predicate: updated
 - Subject: [`change`](#change)
 

--- a/spec.md
+++ b/spec.md
@@ -269,21 +269,21 @@ defined in the [vocabulary](#vocabulary):
 
 ### OPTIONAL Context Attributes
 
-#### schemaURI
+#### schemaUri
 
 - Type: [`URI`][typesystem]
 - Description: link to a `jsonschema` schema that further refines the event schema
   as defined by CDEvents.
 
-  The schema provided by the `schemaURI` must can be stricter than the CDEvents one,
-  but MUST NOT allow elements that would not be allowed by the CDEvents schema.
-  For example the `schemaURI` go define the content of `customData` or restrict a
-  `string` field to a specific `Enum`.
+  The schema provided by the `schemaUri` MUST be stricter than the CDEvents one,
+  and thus MUST NOT allow elements that would not be allowed by the CDEvents schema.
+  For example, the schema at `schemaUri` could define the content of `customData`
+  or restrict a `string` field to a specific `Enum`.
 
-  Versioning of the schema provided in `schemaURI` is up to the maintainer, there
+  Versioning of the schema provided in `schemaUri` is up to the maintainer, there
   is no specific requirement from CDEvents side.
 
-  Consumers of events that specify a `schemaURI` SHOULD validate the event against
+  Consumers of events that specify a `schemaUri` SHOULD validate the event against
   the CDEvents schema as well as the additional schema provided. If the consumer
   does not have access to the URI specified, it SHOULD fail to validate the event.
 
@@ -309,7 +309,7 @@ This is an example of a full CDEvent context, rendered in JSON format:
     "source" : "/staging/tekton/",
     "type" : "dev.cdevents.taskrun.started",
     "timestamp" : "2018-04-05T17:31:00Z",
-    "schemaURI":  "https://myorg.com/cdevents/schema/taskrun-started-1-1-0"
+    "schemaUri":  "https://myorg.com/cdevents/schema/taskrun-started-1-1-0"
   }
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -267,6 +267,36 @@ defined in the [vocabulary](#vocabulary):
   - REQUIRED
   - MUST be a non-empty string
 
+### OPTIONAL Context Attributes
+
+#### schemaURI
+
+- Type: [`URI`][typesystem]
+- Description: link to a `jsonschema` schema that further refines the event schema
+  as defined by CDEvents.
+
+  The schema provided by the `schemaURI` must can be stricter than the CDEvents one,
+  but MUST NOT allow elements that would not be allowed by the CDEvents schema.
+  For example the `schemaURI` go define the content of `customData` or restrict a
+  `string` field to a specific `Enum`.
+
+  Versioning of the schema provided in `schemaURI` is up to the maintainer, there
+  is no specific requirement from CDEvents side.
+
+  Consumers of events that specify a `schemaURI` SHOULD validate the event against
+  the CDEvents schema as well as the additional schema provided. If the consumer
+  does not have access to the URI specified, it SHOULD fail to validate the event.
+
+- Constraints:
+  - OPTIONAL
+  - When specified, it MUST be a non-empty URI
+  - An absolute URI is REQUIRED
+
+- Examples:
+
+  - If there is a single "context" (cloud, cluster or platform of some kind)
+    - `https://myorg.com/cdevents/schema/artifact-published-0-1-0`
+
 ### Context example
 
 This is an example of a full CDEvent context, rendered in JSON format:
@@ -278,7 +308,8 @@ This is an example of a full CDEvent context, rendered in JSON format:
     "id" : "A234-1234-1234",
     "source" : "/staging/tekton/",
     "type" : "dev.cdevents.taskrun.started",
-    "timestamp" : "2018-04-05T17:31:00Z"
+    "timestamp" : "2018-04-05T17:31:00Z",
+    "schemaURI":  "https://myorg.com/cdevents/schema/taskrun-started-1-1-0"
   }
 }
 ```

--- a/testing-events.md
+++ b/testing-events.md
@@ -68,7 +68,7 @@ One or more `testOutput` artifacts are usually produced as the result of a test 
 This event represents when a testCaseRun has been queued for execution - and is waiting for applicable preconditions
 (resource availability, other tasks, etc.) to be fulfilled before actually executing.
 
-- Event Type: __`dev.cdevents.testcaserun.queued.0.1.0`__
+- Event Type: __`dev.cdevents.testcaserun.queued.0.2.0-draft`__
 - Predicate: queued
 - Subject: [`testCaseRun`](#testcaserun)
 
@@ -85,7 +85,7 @@ This event represents when a testCaseRun has been queued for execution - and is 
 
 This event represents a started testCase execution.
 
-- Event Type: __`dev.cdevents.testcaserun.started.0.1.0`__
+- Event Type: __`dev.cdevents.testcaserun.started.0.2.0-draft`__
 - Predicate: started
 - Subject: [`testCaseRun`](#testcaserun)
 
@@ -102,7 +102,7 @@ This event represents a started testCase execution.
 
 This event represents a finished testCase execution. The event will contain the outcome and additional metadata as applicable.
 
-- Event Type: __`dev.cdevents.testcaserun.finished.0.1.0`__
+- Event Type: __`dev.cdevents.testcaserun.finished.0.2.0-draft`__
 - Predicate: finished
 - Subject: [`testCaseRun`](#testcaserun)
 
@@ -122,7 +122,7 @@ This event represents a finished testCase execution. The event will contain the 
 This event represents when a testSuiteRun has been queued for execution - and is waiting for applicable preconditions
 (resource availability, other tasks, etc.) to be met before actually executing.
 
-- Event Type: __`dev.cdevents.testsuiterun.queued.0.1.0`__
+- Event Type: __`dev.cdevents.testsuiterun.queued.0.2.0-draft`__
 - Predicate: queued
 - Subject: [`testSuiteRun`](#testsuiterun)
 
@@ -138,7 +138,7 @@ This event represents when a testSuiteRun has been queued for execution - and is
 
 This event represents a started testSuite execution.
 
-- Event Type: __`dev.cdevents.testsuiterun.started.0.1.0`__
+- Event Type: __`dev.cdevents.testsuiterun.started.0.2.0-draft`__
 - Predicate: started
 - Subject: [`testSuiteRun`](#testsuiterun)
 
@@ -154,7 +154,7 @@ This event represents a started testSuite execution.
 
 This event represents a finished testSuite execution. The event will contain the outcome and additional metadata as applicable.
 
-- Event Type: __`dev.cdevents.testsuiterun.finished.0.1.0`__
+- Event Type: __`dev.cdevents.testsuiterun.finished.0.2.0-draft`__
 - Predicate: finished
 - Subject: [`testSuiteRun`](#testsuiterun)
 
@@ -172,7 +172,7 @@ This event represents a finished testSuite execution. The event will contain the
 
 The event represents a test execution output that has been published.
 
-- Event Type: __`dev.cdevents.testoutput.published.0.1.0`__
+- Event Type: __`dev.cdevents.testoutput.published.0.2.0-draft`__
 - Predicate: published
 - Subject: [`testOutput`](#testoutput)
 


### PR DESCRIPTION
# Changes

Add schemaURI to the context. It can be used to link to a custom schema that further refines the event content.

Context:
- https://github.com/cdevents/spec/issues/168
- https://github.com/cdevents/spec/issues/91

Also fixes a small issue in the `event-version.sh` tool that prevented example versions from being updated.

Fixes: #91

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
