### PR TITLE
Define every `url` and `viewUrl` field as format `uri`

### DIFF
--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -8,13 +8,13 @@ description: >
    CloudEvents Binding for CDEvents
 ---
 -->
-# CloudEvents Binding for CDEvents
+# CloudEvents Binding for CDEvents  <!-- omit in toc -->
 
-## Abstract
+## Abstract <!-- omit in toc -->
 
 The CloudEvents Binding for CDEvents defines how CDEvents are mapped to CloudEvents headers and body.
 
-## Table Of Contents
+## Table Of Contents <!-- omit in toc -->
 
 <!-- toc -->
 - [CloudEvents Context](#cloudevents-context)
@@ -113,7 +113,7 @@ Content-Length: nnnn
       "type": "taskRun",
       "content": {
          "task": "my-task",
-         "url": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123"
+         "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123"
          "pipelineRun": {
             "id": "/somewherelse/pipelinerun-123",
             "source": "/staging/jenkins/"

--- a/conformance/environment_created.json
+++ b/conformance/environment_created.json
@@ -45,7 +45,7 @@
     "type": "environment",
     "content": {
       "name": "testEnv",
-      "url": "https://example.org/testEnv"
+      "uri": "https://example.org/testEnv"
     }
   }
 }

--- a/conformance/environment_modified.json
+++ b/conformance/environment_modified.json
@@ -45,7 +45,7 @@
     "type": "environment",
     "content": {
       "name": "testEnv",
-      "url": "https://example.org/testEnv"
+      "uri": "https://example.org/testEnv"
     }
   }
 }

--- a/conformance/pipelinerun_finished.json
+++ b/conformance/pipelinerun_finished.json
@@ -45,7 +45,7 @@
     "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
-      "url": "https://www.example.com/mySubject123",
+      "uri": "https://www.example.com/mySubject123",
       "outcome": "failure",
       "errors": "Something went wrong\nWith some more details"
     }

--- a/conformance/pipelinerun_queued.json
+++ b/conformance/pipelinerun_queued.json
@@ -45,7 +45,7 @@
     "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
-      "url": "https://www.example.com/mySubject123"
+      "uri": "https://www.example.com/mySubject123"
     }
   }
 }

--- a/conformance/pipelinerun_started.json
+++ b/conformance/pipelinerun_started.json
@@ -45,7 +45,7 @@
     "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
-      "url": "https://www.example.com/mySubject123"
+      "uri": "https://www.example.com/mySubject123"
     }
   }
 }

--- a/conformance/repository_created.json
+++ b/conformance/repository_created.json
@@ -46,7 +46,7 @@
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",
-      "url": "https://example.org/TestOrg/TestRepo",
+      "uri": "https://example.org/TestOrg/TestRepo",
       "viewUrl": "https://example.org/view/TestOrg/TestRepo"
     }
   }

--- a/conformance/repository_deleted.json
+++ b/conformance/repository_deleted.json
@@ -46,7 +46,7 @@
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",
-      "url": "https://example.org/TestOrg/TestRepo",
+      "uri": "https://example.org/TestOrg/TestRepo",
       "viewUrl": "https://example.org/view/TestOrg/TestRepo"
     }
   }

--- a/conformance/repository_modified.json
+++ b/conformance/repository_modified.json
@@ -46,7 +46,7 @@
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",
-      "url": "https://example.org/TestOrg/TestRepo",
+      "uri": "https://example.org/TestOrg/TestRepo",
       "viewUrl": "https://example.org/view/TestOrg/TestRepo"
     }
   }

--- a/conformance/taskrun_finished.json
+++ b/conformance/taskrun_finished.json
@@ -45,7 +45,7 @@
     "type": "taskRun",
     "content": {
       "taskName": "myTask",
-      "url": "https://www.example.com/mySubject123",
+      "uri": "https://www.example.com/mySubject123",
       "pipelineRun": {
         "id": "mySubject123"
       },

--- a/conformance/taskrun_started.json
+++ b/conformance/taskrun_started.json
@@ -45,7 +45,7 @@
     "type": "taskRun",
     "content": {
       "taskName": "myTask",
-      "url": "https://www.example.com/mySubject123",
+      "uri": "https://www.example.com/mySubject123",
       "pipelineRun": {
         "id": "mySubject123"
       }

--- a/links.md
+++ b/links.md
@@ -186,7 +186,7 @@ systems to act accordingly based off the ending notation.
     "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
-      "url": "https://www.example.com/mySubject123"
+      "uri": "https://www.example.com/mySubject123"
     }
   }
 }
@@ -221,7 +221,7 @@ further, we can allow for a path link between `pipelinerun.queued` to the
     "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
-      "url": "https://www.example.com/mySubject123"
+      "uri": "https://www.example.com/mySubject123"
     }
   }
 }
@@ -433,7 +433,7 @@ sender generates this id.
     "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
-      "url": "https://www.example.com/mySubject123"
+      "uri": "https://www.example.com/mySubject123"
     }
   }
 }

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -75,7 +75,7 @@
             "name": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             }

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -75,7 +75,7 @@
             "name": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             }

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -75,7 +75,7 @@
             "pipelineName": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             },

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "outcome": {
               "type": "string"

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -75,7 +75,7 @@
             "pipelineName": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             }

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -75,7 +75,7 @@
             "pipelineName": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             }

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -81,10 +81,11 @@
             },
             "url": {
               "type": "string",
-              "minLength": 1
+              "format": "uri"
             },
             "viewUrl": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -79,7 +79,7 @@
             "owner": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             },

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -78,7 +78,7 @@
             "owner": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             },

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -79,10 +79,12 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "viewUrl": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -78,7 +78,7 @@
             "owner": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             },

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -79,10 +79,12 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "viewUrl": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           },
           "additionalProperties": false,

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "pipelineRun": {
               "properties": {

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -75,7 +75,7 @@
             "taskName": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             },

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -76,7 +76,8 @@
               "type": "string"
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "pipelineRun": {
               "properties": {

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -75,7 +75,7 @@
             "taskName": {
               "type": "string"
             },
-            "url": {
+            "uri": {
               "type": "string",
               "format": "uri"
             },

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -123,7 +123,7 @@
                 "name": {
                   "type": "string"
                 },
-                "url": {
+                "uri": {
                   "type": "string",
                   "format": "uri"
                 }

--- a/spec.md
+++ b/spec.md
@@ -423,7 +423,7 @@ defined in the [vocabulary](#vocabulary):
     ```json
         "content" : {
           "task": "my-task",
-          "url": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123"
+          "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123"
         }
     ```
 
@@ -468,7 +468,7 @@ The following example shows `context` and `subject` together, rendered as JSON.
       "type": "taskRun",
       "content": {
          "task": "my-task",
-         "url": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123",
+         "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123",
          "pipelineRun": {
             "id": "my-distributed-pipelinerun",
             "source": "/tenant1/tekton/"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- define every fields `url` and `viewUrl` with `format: "uri"` as proposed in #191 
- as the version of schema was with suffix `-draft`, I didn't update them

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
