### PR TITLE
Fix custom schema and add validation

### DIFF
--- a/custom/conformance.json
+++ b/custom/conformance.json
@@ -1,0 +1,56 @@
+{
+  "context": {
+    "version": "0.5.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "source": "/event/source/123",
+    "type": "dev.cdeventsx.mytool-resource.created.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/mytool",
+    "chainId": "6ca3f9c5-1cef-4ce0-861c-2456a69cf137",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }, {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }, {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "pkg:resource/name@234fd47e07d1004f0aed9c",
+    "source": "/event/source/123",
+    "type": "mytool-resource",
+    "content": {
+      "user": "mybot-myapp",
+      "description": "a useful resource",
+      "nested": {
+        "key": "value",
+        "list": ["data1", "data2"]
+      }
+    }
+  }
+}
+  

--- a/custom/schema.json
+++ b/custom/schema.json
@@ -19,7 +19,7 @@
         },
         "type": {
           "type": "string",
-          "pattern": "^dev.cdeventsx.[a-zA-Z0-9]+-[a-zA-Z]+.[a-zA-Z]+$"
+          "pattern": "^dev\\.cdeventsx\\.[a-zA-Z0-9]+-[a-zA-Z]+\\.[a-zA-Z]+\\.[0-9]\\.[0-9]\\.[0-9]$"
         },
         "timestamp": {
           "type": "string",
@@ -29,6 +29,13 @@
           "type": "string",
           "minLength": 1,
           "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
         }
       },
       "additionalProperties": false,

--- a/tools/validate.sh
+++ b/tools/validate.sh
@@ -57,7 +57,7 @@ while read -r schema; do
 done <<<$(find "${SCHEMAS_FOLDER}/links" -type f -name 'link*json' -maxdepth 1)
 # Test custom schema
 num_schemas=$(( num_schemas + 1 ))
-ajv compile ${JSON_VALIDATOR_OPTIONS} -r "${EMBEDDED_LINKS_SCHEMAS}" -s custom/schema.json || schema_failed=$(( schema_failed + 1 ))
+ajv compile ${JSON_VALIDATOR_OPTIONS} -r "${EMBEDDED_LINKS_SCHEMAS}" -s "${ROOT}/custom/schema.json" || schema_failed=$(( schema_failed + 1 ))
 
 echo "$(( num_schemas - schema_failed )) out of ${num_schemas} schemas are valid"
 
@@ -77,6 +77,9 @@ find "${EXAMPLES_FOLDER}" -type f -name '*.json' | while read -r example; do
     printf "%s %s: " "${SUBJECT}" "${PREDICATE}"
     ajv validate ${JSON_VALIDATOR_OPTIONS} -r "${EMBEDDED_LINKS_SCHEMAS}" -s "${SCHEMA_FILE}" -d "${example}" || example_failed=$(( example_failed + 1 ))
 done
+# Test custom example
+num_examples=$(( num_examples + 1 ))
+ajv validate ${JSON_VALIDATOR_OPTIONS} -r "${EMBEDDED_LINKS_SCHEMAS}" -s "${ROOT}/custom/schema.json" -d "${ROOT}/custom/conformance.json" || example_failed=$(( example_failed + 1 ))
 
 # Cleanup local schemas
 find "${ROOT}/schemas" -name '*.local' -exec rm {} +


### PR DESCRIPTION
# Changes

The custom schema had a few issues to be fixed:
- missing chainId and links from the context
- missing version in the type regex
- replace "." with "\." in the type regex

This PR fixes all those and adds a conformance.json example file to validate against the custom schema.

Fixes #216

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
