### PR TITLE
chore!: remove subject.type

### DIFF
--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -110,7 +110,6 @@ Content-Length: nnnn
    }
    "subject" : {
       "id": "/namespace/taskrun-123",
-      "type": "taskRun",
       "content": {
          "task": "my-task",
          "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123"

--- a/conformance/artifact_deleted.json
+++ b/conformance/artifact_deleted.json
@@ -41,7 +41,6 @@
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
     "source": "/event/source/123",
-    "type": "artifact",
     "content": {
       "user": "mybot-myapp"
     }

--- a/conformance/artifact_downloaded.json
+++ b/conformance/artifact_downloaded.json
@@ -41,7 +41,6 @@
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
     "source": "/event/source/123",
-    "type": "artifact",
     "content": {
       "user": "mybot-myapp"
     }

--- a/conformance/artifact_packaged.json
+++ b/conformance/artifact_packaged.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
     "source": "/event/source/123",
-    "type": "artifact",
     "content": {
       "change": {
         "id": "myChange123",

--- a/conformance/artifact_published.json
+++ b/conformance/artifact_published.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
     "source": "/event/source/123",
-    "type": "artifact",
     "content": {
       "sbom": {
         "uri": "https://sbom.repo/myorg/234fd47e07d1004f0aed9c.sbom"

--- a/conformance/artifact_signed.json
+++ b/conformance/artifact_signed.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
     "source": "/event/source/123",
-    "type": "artifact",
     "content": {
       "signature": "MEYCIQCBT8U5ypDXWCjlNKfzTV4KH516/SK13NZSh8znnSMNkQIhAJ3XiQlc9PM1KyjITcZXHotdMB+J3NGua5T/yshmiPmp"
     }

--- a/conformance/branch_created.json
+++ b/conformance/branch_created.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "branch",
     "content": {
       "repository": {
         "id": "TestRepo/TestOrg",

--- a/conformance/branch_deleted.json
+++ b/conformance/branch_deleted.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "branch",
     "content": {
       "repository": {
         "id": "TestRepo/TestOrg",

--- a/conformance/build_finished.json
+++ b/conformance/build_finished.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "build",
     "content": {
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427"
     }

--- a/conformance/build_queued.json
+++ b/conformance/build_queued.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "build",
     "content": {}
   }
 }

--- a/conformance/build_started.json
+++ b/conformance/build_started.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "build",
     "content": {}
   }
 }

--- a/conformance/change_abandoned.json
+++ b/conformance/change_abandoned.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "change",
     "content": {
       "repository": {
         "id": "TestRepo/TestOrg",

--- a/conformance/change_created.json
+++ b/conformance/change_created.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "change",
     "content": {
       "description": "This PR address a bug from a recent PR",
       "repository": {

--- a/conformance/change_merged.json
+++ b/conformance/change_merged.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "change",
     "content": {
       "repository": {
         "id": "TestRepo/TestOrg",

--- a/conformance/change_reviewed.json
+++ b/conformance/change_reviewed.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "change",
     "content": {
       "repository": {
         "id": "TestRepo/TestOrg",

--- a/conformance/change_updated.json
+++ b/conformance/change_updated.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "change",
     "content": {
       "repository": {
         "id": "TestRepo/TestOrg",

--- a/conformance/environment_created.json
+++ b/conformance/environment_created.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "environment",
     "content": {
       "name": "testEnv",
       "uri": "https://example.org/testEnv"

--- a/conformance/environment_deleted.json
+++ b/conformance/environment_deleted.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "environment",
     "content": {
       "name": "testEnv"
     }

--- a/conformance/environment_modified.json
+++ b/conformance/environment_modified.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "environment",
     "content": {
       "name": "testEnv",
       "uri": "https://example.org/testEnv"

--- a/conformance/incident_detected.json
+++ b/conformance/incident_detected.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "incident-123",
     "source": "/monitoring/prod1",
-    "type": "incident",
     "content": {
       "description": "Response time above threshold of 100ms",
       "environment": {

--- a/conformance/incident_reported.json
+++ b/conformance/incident_reported.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "incident-123",
     "source": "/monitoring/prod1",
-    "type": "incident",
     "content": {
       "description": "Response time above threshold of 100ms",
       "environment": {

--- a/conformance/incident_resolved.json
+++ b/conformance/incident_resolved.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "incident-123",
     "source": "/monitoring/prod1",
-    "type": "incident",
     "content": {
       "description": "Response time restored below 100ms",
       "environment": {

--- a/conformance/pipelinerun_finished.json
+++ b/conformance/pipelinerun_finished.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123",

--- a/conformance/pipelinerun_queued.json
+++ b/conformance/pipelinerun_queued.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"

--- a/conformance/pipelinerun_started.json
+++ b/conformance/pipelinerun_started.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"

--- a/conformance/repository_created.json
+++ b/conformance/repository_created.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "repository",
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",

--- a/conformance/repository_deleted.json
+++ b/conformance/repository_deleted.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "repository",
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",

--- a/conformance/repository_modified.json
+++ b/conformance/repository_modified.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "repository",
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",

--- a/conformance/service_deployed.json
+++ b/conformance/service_deployed.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "service",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_published.json
+++ b/conformance/service_published.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "service",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_removed.json
+++ b/conformance/service_removed.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "service",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_rolledback.json
+++ b/conformance/service_rolledback.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "service",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_upgraded.json
+++ b/conformance/service_upgraded.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "service",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/taskrun_finished.json
+++ b/conformance/taskrun_finished.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "taskRun",
     "content": {
       "taskName": "myTask",
       "uri": "https://www.example.com/mySubject123",

--- a/conformance/taskrun_started.json
+++ b/conformance/taskrun_started.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "taskRun",
     "content": {
       "taskName": "myTask",
       "uri": "https://www.example.com/mySubject123",

--- a/conformance/testcaserun_finished.json
+++ b/conformance/testcaserun_finished.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "myTestCaseRun123",
     "source": "/event/source/123",
-    "type": "testCaseRun",
     "content": {
       "outcome": "success",
       "environment": {

--- a/conformance/testcaserun_queued.json
+++ b/conformance/testcaserun_queued.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "myTestCaseRun123",
     "source": "/event/source/123",
-    "type": "testCaseRun",
     "content": {
       "environment": {
         "id": "dev",

--- a/conformance/testcaserun_skipped.json
+++ b/conformance/testcaserun_skipped.json
@@ -41,7 +41,6 @@
   "subject": {
     "id": "myTestCaseRun123",
     "source": "/event/source/123",
-    "type": "testCaseRun",
     "content": {
       "reason": "Not running in this environment",
       "environment": {

--- a/conformance/testcaserun_started.json
+++ b/conformance/testcaserun_started.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "myTestCaseRun123",
     "source": "/event/source/123",
-    "type": "testCaseRun",
     "content": {
       "environment": {
         "id": "dev",

--- a/conformance/testoutput_published.json
+++ b/conformance/testoutput_published.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "testrunreport-12123",
     "source": "/event/source/testrunreport-12123",
-    "type": "testOutput",
     "content": {
       "outputType": "video",
       "format": "video/quicktime",

--- a/conformance/testsuiterun_finished.json
+++ b/conformance/testsuiterun_finished.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "myTestSuiteRun123",
     "source": "/event/source/123",
-    "type": "testSuiteRun",
     "content": {
       "outcome": "failure",
       "severity": "critical",

--- a/conformance/testsuiterun_queued.json
+++ b/conformance/testsuiterun_queued.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "myTestSuiteRun123",
     "source": "/event/source/123",
-    "type": "testSuiteRun",
     "content": {
       "environment": {
         "id": "dev",

--- a/conformance/testsuiterun_started.json
+++ b/conformance/testsuiterun_started.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "myTestSuiteRun123",
     "source": "/event/source/123",
-    "type": "testSuiteRun",
     "content": {
       "environment": {
         "id": "dev",

--- a/conformance/ticket_closed.json
+++ b/conformance/ticket_closed.json
@@ -41,7 +41,6 @@
   "subject": {
     "id": "ticket-123",
     "source": "/ticketing/system",
-    "type": "ticket",
     "content": {
       "summary": "New CVE-123 detected",
       "ticketType": "task",

--- a/conformance/ticket_created.json
+++ b/conformance/ticket_created.json
@@ -41,7 +41,6 @@
   "subject": {
     "id": "ticket-123",
     "source": "/ticketing/system",
-    "type": "ticket",
     "content": {
       "summary": "New CVE-123 detected",
       "ticketType": "task",

--- a/conformance/ticket_updated.json
+++ b/conformance/ticket_updated.json
@@ -41,7 +41,6 @@
   "subject": {
     "id": "ticket-123",
     "source": "/ticketing/system",
-    "type": "ticket",
     "content": {
       "summary": "New CVE-123 detected",
       "ticketType": "task",

--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -29,7 +29,6 @@ An `environment` is a platform which may run a `service`.
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](spec.md#type-subject) | `environment` |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`|
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`|
 
@@ -41,7 +40,6 @@ A `service` can represent for example a binary that is running, a daemon, an app
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](spec.md#type-subject) | `service` |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
@@ -59,7 +57,6 @@ This event represents an environment that has been created. Such an environment 
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -75,7 +72,6 @@ This event represents an environment that has been modified.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 | url | `String` | URL to reference where the environment is located | `https://my-cluster.zone.my-cloud-provider`| |
 
@@ -91,7 +87,6 @@ This event represents an environment that has been deleted.```
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `environment` | |
 | name | `String` | Name of the environment | `dev`, `staging`, `production`, `ci-123`| |
 
 ### [`service deployed`](conformance/service_deployed.json)
@@ -106,7 +101,6 @@ This event represents a new instance of a service that has been deployed
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `927aa808433d17e315a258b98e2f1a55f8258e0cb782ccb76280646d0dbe17b5`, `six-1.14.0-py2.py3-none-any.whl` | ✅ |
 
@@ -122,7 +116,6 @@ This event represents an existing instance of a service that has been upgraded t
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |`pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
@@ -138,7 +131,6 @@ This event represents an existing instance of a service that has been rolled bac
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 
@@ -154,7 +146,6 @@ This event represents the removal of a previously deployed service instance and 
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
 
 ### [`service published`](conformance/service_published.json)
@@ -169,5 +160,4 @@ This event represents an existing instance of a service that has an accessible U
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `service` | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |

--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -33,7 +33,6 @@ __Note:__ The data model for `build`, apart from `id` and `source`, only include
 |-------|------|-------------|----------|
 | id    | `String` | Uniquely identifies the subject within the source. | `1234`, `maven123`, `builds/taskrun123` |
 | source | `URI-Reference` | [source](../spec.md#source) from the context | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](spec.md#type-subject) | `build` |
 | artifactId | `String` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 
 ### `artifact`
@@ -44,7 +43,6 @@ An `artifact` is usually produced as output of a build process. Events need to b
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
-| type | `String` | See [type](spec.md#type-subject) | `artifact` |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` |
 | signature | `string`     | The signature of the artifact | `MEYCIQCBT8U5ypDXWCjlNKfzTV4KH516/SK13NZSh8znnSMNkQIhAJ3XiQlc9PM1KyjITcZXHotdMB+J3NGua5T/yshmiPmp` |
 | sbom | [`sbom`](#sbom) | The Software Bill of Material (SBOM) associated with the artifact | `{"uri": "https://sbom.storage.service/my-projects/3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427.sbom"}` |
@@ -64,7 +62,6 @@ This event represents a Build task that has been queued; this build process usua
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `build` | |
 
 ### [`build started`](conformance/build_started.json)
 
@@ -78,7 +75,6 @@ This event represents a Build task that has been started; this build process usu
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `build` | |
 
 ### [`build finished`](conformance/build_finished.json)
 
@@ -92,7 +88,6 @@ This event represents a Build task that has finished. This event will eventually
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `maven123`, `builds/taskrun123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | |
 | artifactId | `Purl` | Identifier of the artifact produced by the build | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | `build` | |
 
 ### [`artifact packaged`](conformance/artifact_packaged.json)
@@ -108,7 +103,6 @@ This event is usually produced by the build system. If an SBOM URI is available 
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `artifact` | |
 | change | `object`        | The change (tag, commit, revision) of the repository which was used to build the artifact" | `{"id": "527d4a1aca5e8d0df24813df5ad65d049fc8d312", "source": "my-git.example/an-org/a-repo"}`, `{"id": "feature1234", "source": "my-git.example/an-org/a-repo"}` | ✅ |
 | sbom | [`sbom`](#sbom) | The Software Bill of Material (SBOM) associated with the artifact | `{"uri": "https://sbom.storage.service/my-projects/3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427.sbom"}` | |
 
@@ -125,7 +119,6 @@ An artifact may be signed after it has been packaged or sometimes after it has p
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `artifact` | |
 | signature | `string`     | The signature of the artifact | `MEYCIQCBT8U5ypDXWCjlNKfzTV4KH516/SK13NZSh8znnSMNkQIhAJ3XiQlc9PM1KyjITcZXHotdMB+J3NGua5T/yshmiPmp` | ✅ |
 
 ### [`artifact published`](conformance/artifact_published.json)
@@ -141,7 +134,6 @@ The `artifact published` event is typically produced by the artifact registry, b
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `artifact` | |
 | user | `String` | The user who published to the artifact registry. [^user] | `mybot-myapp` | |
 
 ### [`artifact downloaded`](conformance/artifact_downloaded.json)
@@ -157,7 +149,6 @@ The `artifact downloaded` event is preferably produced by the artifact registry.
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `artifact` | |
 | user | `String` | The user who downloaded from the artifact registry. [^user] | `mybot-myapp` | |
 
 ### [`artifact deleted`](conformance/artifact_deleted.json)
@@ -173,7 +164,6 @@ The `artifact deleted` event is preferably produced by the artifact registry.
 |-------|------|-------------|----------|----------------------------|
 | id    | `Purl` | See [id](spec.md#id-subject) | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427?repository_url=mycr.io/myapp`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `artifact` | |
 | user | `String` | The user who deleted from the artifact registry. [^user] | `mybot-myapp` | |
 
 [^user]: The actual format of `user` depends on the specific registry and authentication method used. If access to the artifact registry is obtained through a long lived token, this could be the name or description associated with the token at provisioning time. In case of an anonymous read operations, the user depends on the protocol used, a typically useful value would be the IP address of the client performing the read.

--- a/continuous-operations.md
+++ b/continuous-operations.md
@@ -29,7 +29,6 @@ An `incident` represents a problem in a production environment. To quote the def
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA` |
-| type | `String` | See [type](spec.md#type-subject) | `incident` |
 | description | `String` | Short, free style description of the incident | `Response time above 10ms`, `New CVE-123 detected` |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` |
@@ -43,7 +42,6 @@ A ticket can request a change, report a problem, or document an [`incident`](#in
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `ticket123`, `risk-CVE123` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `ticketing-system` |
-| type | `String` | See [type](spec.md#type-subject) | `ticket` |
 | summary | `String` | The summary provided on the ticket | `Implement feature xyz`, `New CVE-123 detected` |
 | ticketType | `Enum or String` | The ticket type | `bug`, `enhancement`, `incident`, `task`, `question`, `custom-value` |
 | group | `String` | The group or project the ticket is currently assigned to | `backend` |
@@ -70,7 +68,6 @@ This event represents an incident that has been detected by a system or human.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `ticket123`, `risk-CVE123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
-| type | `String` | See [type](spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident | `Response time above 10ms`, `New CVE-123 detected` | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |
@@ -88,7 +85,6 @@ This event represents an incident that has been reported through a ticketing sys
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `ticket123`, `risk-CVE123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
-| type | `String` | See [type](spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident | `Response time above 10ms`, `New CVE-123 detected` | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | ticketURI | `URI` | URI of the ticket |  `example.issues.com/ticket123` | ✅ |
@@ -107,7 +103,6 @@ This event represents an incident that has been resolved, meaning that the probl
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `04896C75-F34D-40FF-A584-3F2B71CB9D47`, `issue123`, `risk-CVE123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `region1/production`, `monitoring-system/metricA`| |
-| type | `String` | See [type](spec.md#type-subject) | `incident` | |
 | description | `String` | Short, free style description of the incident resolution | `Response time restored below 10ms`, `CVE-123 acknowledged as non-exploitable` | |
 | environment | `Object` ([`environment`](./continuous-deployment.md#environment)) | Reference to the environment | `{"id": "production"}`, `{"id": "staging"}`, `{"id": "prod123", "source": "iaas-region-1"}` | ✅ |
 | service | `Object` ([`service`](./continuous-deployment.md#service)) | Reference to the service | `{"id": "service123"}`, `{"id": "service123", "source": "region1/k8s/namespace"}` | |
@@ -125,7 +120,6 @@ This event represents a ticket that has been created within some ticketing syste
 | ------|----- | ----------- | ---------| ------------ |
 | id | `String`| See [id](spec.md#id-subject) | `ticket-123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `ticketing-system` | |
-| type | `String` | See [type](spec.md#type-subject) | `ticket` | |
 | summary | `String` | The summary provided on the ticket | `Implement feature xyz`, `New CVE-123 detected` | ✅ |
 | ticketType | `Enum or String` | The ticket type | `bug`, `enhancement`, `incident`, `task`, `question`, `custom-value` | |
 | creator | `String` | The ticket author | `Alice` | ✅ |
@@ -148,7 +142,6 @@ This event indicates that a ticket has been updated within some ticketing system
 | ------|----- | ----------- | ---------| ------------ |
 | id | `String`| See [id](spec.md#id-subject) | `ticket-123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `ticketing-system` | |
-| type | `String` | See [type](spec.md#type-subject) | `ticket` | |
 | summary | `String` | The summary provided on the ticket | `Implement feature xyz`, `New CVE-123 detected` | |
 | ticketType | `Enum or String` | The ticket type | `bug`, `enhancement`, `incident`, `task`, `question`, `custom-value` | |
 | creator | `String` | The ticket author | `Alice` | |
@@ -172,7 +165,6 @@ This event indicates that a ticket has been closed or resolved within some ticke
 | ------|----- | ----------- | ---------| ------------ |
 | id | `String`| See [id](spec.md#id-subject) | `ticket-123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `ticketing-system` | |
-| type | `String` | See [type](spec.md#type-subject) | `ticket` | |
 | summary | `String` | The summary provided on the ticket | `Implement feature xyz`, `New CVE-123 detected` | |
 | ticketType | `Enum or String` | The ticket type | `bug`, `enhancement`, `incident`, `task`, `question`, `custom-value` | |
 | creator | `String` | The ticket author | `Alice` | |

--- a/core.md
+++ b/core.md
@@ -34,7 +34,6 @@ track the build and release progress on a particular software artifact.
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | |
-| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | outcome | `String` | outcome of a finished `pipelineRun` | `success`, `failure`, `cancel`, or `error` |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` |
@@ -53,7 +52,6 @@ associated, in which case it is acceptable to generate only taskRun events.
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | |
-| type | `String` | See [type](spec.md#type-subject) | `taskRun` |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`|
 | outcome | `String` | outcome of a finished `taskRun` | `success`, `failure`, `cancel`, or `error` |
@@ -76,7 +74,6 @@ to ignore these events if they don't apply to their use cases.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -92,7 +89,6 @@ A pipelineRun has started and it is running.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 
@@ -108,7 +104,6 @@ A pipelineRun has finished, successfully or not.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/pipelinerun-1234` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
-| type | `String` | See [type](spec.md#type-subject) | `pipelineRun` | |
 | pipelineName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | url | `URI` | url to the `pipelineRun` | `https://dashboard.org/namespace/pipelinerun-1234`, `https://api.cdsystem.com/namespace/pipelinerun-1234` | |
 | outcome | `String (enum)` | outcome of a finished `pipelineRun` | `success`, `failure`, `cancel`, or `error` | `success`, `failure`, `cancel`, `error` |
@@ -126,7 +121,6 @@ A taskRun has started and it is running.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
 | source | `URI-Reference` | [source](spec.md#source) from the context | | |
-| type | `String` | See [type](spec.md#type-subject) | `taskRun` | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`| |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |
@@ -143,7 +137,6 @@ A taskRun has finished, successfully or not.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `tenant1/12345-abcde`, `namespace/taskrun-1234` | ✅ |
 | source | `URI-Reference` | [source](spec.md#source) from the context | | |
-| type | `String` | See [type](spec.md#type-subject) | `taskRun` | |
 | taskName  | `String` | The name of the pipeline | `MyPipeline`, `Unit tests for my repo` | |
 | pipelineRun | `Object` ([`pipelineRun`](#pipelinerun)) | The `pipelineRun` that this `taskRun` belongs to. | `{"id": "namespace/pipelinerun-1234"}`| |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |

--- a/custom/README.md
+++ b/custom/README.md
@@ -122,7 +122,6 @@ Corresponding CDEvent using a `dev.cdeventsx.*` type:
   "subject": {
     "id": "/projects/2/webhook/policies/15",
     "source": "/harbor/alpine",
-    "type": "quota",
     "content": {
       "operator": "",
       "resources": [

--- a/custom/conformance.json
+++ b/custom/conformance.json
@@ -42,7 +42,6 @@
   "subject": {
     "id": "pkg:resource/name@234fd47e07d1004f0aed9c",
     "source": "/event/source/123",
-    "type": "mytool-resource",
     "content": {
       "user": "mybot-myapp",
       "description": "a useful resource",
@@ -53,4 +52,3 @@
     }
   }
 }
-  

--- a/custom/schema.json
+++ b/custom/schema.json
@@ -59,10 +59,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "pattern": "^[a-zA-Z0-9]+-[a-zA-Z]+$"
-        },
         "content": {
           "type": "object",
           "additionalProperties": true
@@ -72,7 +68,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/links.md
+++ b/links.md
@@ -139,7 +139,6 @@ between CDEvents.
   "subject": {
     "id": "MyTestSuite",
     "source": "/tests/com/org/package",
-    "type": "testSuite",
     "content": {}
   }
 }
@@ -183,7 +182,6 @@ systems to act accordingly based off the ending notation.
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"
@@ -218,7 +216,6 @@ further, we can allow for a path link between `pipelinerun.queued` to the
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"
@@ -293,7 +290,7 @@ be able to construct the links between those events by itself.
    |            |            |                                                                           |<-----------------------|
    |            |            |           #4 (receive change merged event)                                |                        |
    |            |<----------------------------------------------------------------------------------------------------------------+
-   |            |            |           #5 (send pipeline queued event)                                 |                        | 
+   |            |            |           #5 (send pipeline queued event)                                 |                        |
    |            +---------------------------------------------------------------------------------------------------------------->|
    |            |            |           #6 (source change links connecting #1 -> #5)                    |                        |
    |            +---------------------------------------------------------------------------------------------------------------->|
@@ -330,7 +327,7 @@ be able to construct the links between those events by itself.
    |            |            |                                                                           |  #23 (proxy link #22)  |
    |            |            |                                                                           |<-----------------------|
    |            |            |           #24 (receive pipeline finished event)                           |                        |
-   |            |            |<---------------------------------------------------------------------------------------------------+ 
+   |            |            |<---------------------------------------------------------------------------------------------------+
    |            |            |           #25 (send pipeline queued event)                                |                        |
    |            |            +--------------------------------------------------------------------------------------------------->|
    |            |            |           #26 (pipeline finished event links connecting #21 -> #25)       |                        |
@@ -430,7 +427,6 @@ sender generates this id.
   "subject": {
     "id": "mySubject123",
     "source": "/event/source/123",
-    "type": "pipelineRun",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"

--- a/schemas/artifactdeleted.json
+++ b/schemas/artifactdeleted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "artifact"
-          ],
-          "default": "artifact"
-        },
         "content": {
           "properties": {
             "user": {
@@ -85,7 +77,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/artifactdownloaded.json
+++ b/schemas/artifactdownloaded.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "artifact"
-          ],
-          "default": "artifact"
-        },
         "content": {
           "properties": {
             "user": {
@@ -85,7 +77,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "artifact"
-          ],
-          "default": "artifact"
-        },
         "content": {
           "properties": {
             "change": {
@@ -116,7 +108,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "artifact"
-          ],
-          "default": "artifact"
-        },
         "content": {
           "properties": {
             "sbom": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/artifactsigned.json
+++ b/schemas/artifactsigned.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "artifact"
-          ],
-          "default": "artifact"
-        },
         "content": {
           "properties": {
             "signature": {
@@ -88,7 +80,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "branch"
-          ],
-          "default": "branch"
-        },
         "content": {
           "properties": {
             "repository": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "branch"
-          ],
-          "default": "branch"
-        },
         "content": {
           "properties": {
             "repository": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "build"
-          ],
-          "default": "build"
-        },
         "content": {
           "properties": {
             "artifactId": {
@@ -84,7 +76,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "build"
-          ],
-          "default": "build"
-        },
         "content": {
           "properties": {},
           "additionalProperties": false,
@@ -80,7 +72,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "build"
-          ],
-          "default": "build"
-        },
         "content": {
           "properties": {},
           "additionalProperties": false,
@@ -80,7 +72,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "change"
-          ],
-          "default": "change"
-        },
         "content": {
           "properties": {
             "repository": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "change"
-          ],
-          "default": "change"
-        },
         "content": {
           "properties": {
             "description": {
@@ -103,7 +95,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "change"
-          ],
-          "default": "change"
-        },
         "content": {
           "properties": {
             "repository": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "change"
-          ],
-          "default": "change"
-        },
         "content": {
           "properties": {
             "repository": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "change"
-          ],
-          "default": "change"
-        },
         "content": {
           "properties": {
             "repository": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "environment"
-          ],
-          "default": "environment"
-        },
         "content": {
           "properties": {
             "name": {
@@ -88,7 +80,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "environment"
-          ],
-          "default": "environment"
-        },
         "content": {
           "properties": {
             "name": {
@@ -84,7 +76,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "environment"
-          ],
-          "default": "environment"
-        },
         "content": {
           "properties": {
             "name": {
@@ -88,7 +80,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "incident"
-          ],
-          "default": "incident"
-        },
         "content": {
           "properties": {
             "description": {
@@ -127,7 +119,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "incident"
-          ],
-          "default": "incident"
-        },
         "content": {
           "properties": {
             "description": {
@@ -133,7 +125,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "incident"
-          ],
-          "default": "incident"
-        },
         "content": {
           "properties": {
             "description": {
@@ -127,7 +119,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -54,12 +54,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": ["pipelineRun"],
-          "default": "pipelineRun"
-        },
         "content": {
           "properties": {
             "pipelineName": {
@@ -83,7 +77,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["id", "type", "content"]
+      "required": ["id", "content"]
     },
     "customData": {
       "oneOf": [

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "pipelineRun"
-          ],
-          "default": "pipelineRun"
-        },
         "content": {
           "properties": {
             "pipelineName": {
@@ -88,7 +80,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "pipelineRun"
-          ],
-          "default": "pipelineRun"
-        },
         "content": {
           "properties": {
             "pipelineName": {
@@ -92,7 +84,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "repository"
-          ],
-          "default": "repository"
-        },
         "content": {
           "properties": {
             "name": {
@@ -100,7 +92,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "repository"
-          ],
-          "default": "repository"
-        },
         "content": {
           "properties": {
             "name": {
@@ -95,7 +87,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "repository"
-          ],
-          "default": "repository"
-        },
         "content": {
           "properties": {
             "name": {
@@ -95,7 +87,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "service"
-          ],
-          "default": "service"
-        },
         "content": {
           "properties": {
             "environment": {
@@ -107,7 +99,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "service"
-          ],
-          "default": "service"
-        },
         "content": {
           "properties": {
             "environment": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "service"
-          ],
-          "default": "service"
-        },
         "content": {
           "properties": {
             "environment": {
@@ -99,7 +91,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "service"
-          ],
-          "default": "service"
-        },
         "content": {
           "properties": {
             "environment": {
@@ -107,7 +99,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "service"
-          ],
-          "default": "service"
-        },
         "content": {
           "properties": {
             "environment": {
@@ -107,7 +99,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "taskRun"
-          ],
-          "default": "taskRun"
-        },
         "content": {
           "properties": {
             "taskName": {
@@ -112,7 +104,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "taskRun"
-          ],
-          "default": "taskRun"
-        },
         "content": {
           "properties": {
             "taskName": {
@@ -106,7 +98,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/testcaserunfinished.json
+++ b/schemas/testcaserunfinished.json
@@ -51,12 +51,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": ["testCaseRun"],
-          "default": "testCaseRun"
-        },
         "content": {
           "properties": {
             "outcome": {
@@ -142,7 +136,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["id", "type", "content"]
+      "required": ["id", "content"]
     },
     "customData": {
       "oneOf": [

--- a/schemas/testcaserunqueued.json
+++ b/schemas/testcaserunqueued.json
@@ -59,14 +59,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "testCaseRun"
-          ],
-          "default": "testCaseRun"
-        },
         "content": {
           "properties": {
             "trigger": {
@@ -170,7 +162,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/testcaserunskipped.json
+++ b/schemas/testcaserunskipped.json
@@ -59,14 +59,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "testCaseRun"
-          ],
-          "default": "testCaseRun"
-        },
         "content": {
           "properties": {
             "reason": {
@@ -152,7 +144,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/testcaserunstarted.json
+++ b/schemas/testcaserunstarted.json
@@ -59,14 +59,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "testCaseRun"
-          ],
-          "default": "testCaseRun"
-        },
         "content": {
           "properties": {
             "trigger": {
@@ -170,7 +162,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/testoutputpublished.json
+++ b/schemas/testoutputpublished.json
@@ -59,14 +59,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "testOutput"
-          ],
-          "default": "testOutput"
-        },
         "content": {
           "properties": {
             "outputType": {
@@ -116,7 +108,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/testsuiterunfinished.json
+++ b/schemas/testsuiterunfinished.json
@@ -51,12 +51,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": ["testSuiteRun"],
-          "default": "testSuiteRun"
-        },
         "content": {
           "properties": {
             "environment": {
@@ -115,7 +109,7 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": ["id", "type", "content"]
+      "required": ["id", "content"]
     },
     "customData": {
       "oneOf": [

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -59,14 +59,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "testSuiteRun"
-          ],
-          "default": "testSuiteRun"
-        },
         "content": {
           "properties": {
             "trigger": {
@@ -141,7 +133,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/testsuiterunstarted.json
+++ b/schemas/testsuiterunstarted.json
@@ -59,14 +59,6 @@
         "source": {
           "type": "string"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "testSuiteRun"
-          ],
-          "default": "testSuiteRun"
-        },
         "content": {
           "properties": {
             "trigger": {
@@ -141,7 +133,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/ticketclosed.json
+++ b/schemas/ticketclosed.json
@@ -166,7 +166,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/ticketcreated.json
+++ b/schemas/ticketcreated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "ticket"
-          ],
-          "default": "ticket"
-        },
         "content": {
           "properties": {
             "summary": {
@@ -148,7 +140,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/schemas/ticketupdated.json
+++ b/schemas/ticketupdated.json
@@ -62,14 +62,6 @@
           "minLength": 1,
           "format": "uri-reference"
         },
-        "type": {
-          "type": "string",
-          "minLength": 1,
-          "enum": [
-            "ticket"
-          ],
-          "default": "ticket"
-        },
         "content": {
           "properties": {
             "summary": {
@@ -149,7 +141,6 @@
       "type": "object",
       "required": [
         "id",
-        "type",
         "content"
       ]
     },

--- a/source-code-version-control.md
+++ b/source-code-version-control.md
@@ -32,7 +32,6 @@ An SCM `repository` is identified by a `name`, an `owner` which can be a user or
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
-| type | `String` | See [type](spec.md#type-subject) | `repository` |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`|
 | url | `URI` | URL to the `repository` for API operations. This URL needs to include the protocol used to connect to the repository. | `git://my-git.example/an-org/a-repo` |
@@ -46,7 +45,6 @@ A `branch` in an SCM repository is identified by its `id`.
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
-| type | `String` | See [type](spec.md#type-subject) | `branch` |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
 ### `change`
@@ -57,7 +55,6 @@ A `change` identifies a proposed set of changes to the content of a `repository`
 |-------|------|-------------|----------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`|
-| type | `String` | See [type](spec.md#type-subject) | `change` |
 | description | `String` | Description associated with the change, e.g. A pull request's description | `This PR addresses a fix for some feature`|
 | repository | `Object` ([`repository`](#repository)) | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` |
 
@@ -75,7 +72,6 @@ A new Source Code Repository was created to host source code for a project.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`| |
-| type | `String` | See [type](spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -93,7 +89,6 @@ A Source Code Repository modified some of its attributes, like location, or owne
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`| |
-| type | `String` | See [type](spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | ✅ |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | ✅ |
@@ -109,7 +104,6 @@ A Source Code Repository modified some of its attributes, like location, or owne
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `an-org/a-repo`, `an-user/a-repo`, `repo123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example`| |
-| type | `String` | See [type](spec.md#type-subject) | `repository` | |
 | name  | `String` | The name of the `repository` | `spec`, `community`, `a-repo` | |
 | owner | `String` | The owner of the `repository` | `cdevents`, `an-org`, `an-user`| |
 | url | `URI` | URL to the `repository` | `git://my-git.example/an-org/a-repo` | |
@@ -127,7 +121,6 @@ A branch inside the Repository was created.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](spec.md#type-subject) | `branch` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### [`branch deleted`](conformance/branch_deleted.json)
@@ -142,7 +135,6 @@ A branch inside the Repository was deleted.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `main`, `feature-a`, `fix-issue-1` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-rep`| |
-| type | `String` | See [type](spec.md#type-subject) | `branch` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### [`change created`](conformance/change_created.json)
@@ -157,7 +149,6 @@ A source code change was created and submitted to a repository specific branch. 
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | description | `String` | Description associated with the change, e.g. A pull request's description | `This PR addresses a fix for some feature`| |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
@@ -173,7 +164,6 @@ Someone (user) or an automated system submitted an review to the source code cha
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### [`change merged`](conformance/change_merged.json)
@@ -188,7 +178,6 @@ A change is merged to the target branch where it was submitted.
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123`, `1a429d2f06fa49d8ece5045ac6471dc8a2276895` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### [`change abandoned`](conformance/change_abandoned.json)
@@ -203,7 +192,6 @@ A tool or a user decides that the change has been inactive for a while and it ca
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |
 
 ### [`change updated`](conformance/change_updated.json)
@@ -218,5 +206,4 @@ A Change has been updated, for example a new commit is added or removed from an 
 |-------|------|-------------|----------|----------------------------|
 | id    | `String` | See [id](spec.md#id-subject)| `1234`, `featureBranch123` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `my-git.example/an-org/a-repo`| |
-| type | `String` | See [type](spec.md#type-subject) | `change` | |
 | repository | `Object` | A reference to the repository where the change event happened | `{"id": "an-org/a-repo"}` | |

--- a/spec.md
+++ b/spec.md
@@ -42,7 +42,6 @@ CDEvents is a common specification for Continuous Delivery events.
     - [content](#content)
   - [OPTIONAL Subject Attributes](#optional-subject-attributes)
     - [source (subject)](#source-subject)
-    - [type (subject)](#type-subject)
   - [Subject example](#subject-example)
 - [CDEvents custom data](#cdevents-custom-data)
   - [OPTIONAL Custom Data attributes](#optional-custom-data-attributes)
@@ -441,15 +440,6 @@ defined in the [vocabulary](#vocabulary):
   The format and semantic of the *subject* [`source`](#source-subject) are the
   same of those of the *context* [`source`](#source-context).
 
-#### type (subject)
-
-- Type: `Enum`
-- Description: A string defined in the [vocabulary](#vocabulary) that
-  identifies the type of [`subject`](#cdevent-subject).
-
-- Constraints:
-  - REQUIRED when [`content`](#content) is not empty
-
 ### Subject example
 
 The following example shows `context` and `subject` together, rendered as JSON.
@@ -465,7 +455,6 @@ The following example shows `context` and `subject` together, rendered as JSON.
    },
    "subject" : {
       "id": "my-taskrun-123",
-      "type": "taskRun",
       "content": {
          "task": "my-task",
          "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123",


### PR DESCRIPTION
# Changes

SEE #189

Remove the field `subject.type` from:

- JSON schema & conformance sample
- custom event work
- documentation

The types with camel case (e.g. pipelineRun, testCaseRun) were not changed in the documentation, but should no longer be present in the JSON schema & samples.

The changes are split into commit, to ease the review (if you want). It was a manual operation, I ran validate.sh locally, the only reported error is due to an other issue fixed into an other PR #261 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [ ] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
