### PR TITLE
update(link): Relax link schemas to support domain-level identifiers

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -56,6 +56,7 @@ rolledback
 runtime
 sbom
 schemaUri
+schemas
 schemauri
 specversion
 src

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -1,0 +1,5 @@
+# CDEvents Provider Registry
+
+The canonical registry of known `provider` values is [`schemas/registry/providers.json`](schemas/registry/providers.json). SDKs MUST use this list as the default for provider validation. See the [Provider Validation](links.md#provider-validation) section in `links.md` for the full SDK validation requirements.
+
+To register a provider, open a pull request adding an entry to the enum in [`schemas/registry/providers.json`](schemas/registry/providers.json). Provider identifiers MUST be lowercase, start with a letter, and contain only alphanumeric characters and hyphens. Once merged, the value is considered stable and MUST NOT be renamed.

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -2,4 +2,4 @@
 
 The canonical registry of known `provider` values is [`schemas/registry/providers.json`](schemas/registry/providers.json). SDKs MUST use this list as the default for provider validation. See the [Provider Validation](links.md#provider-validation) section in `links.md` for the full SDK validation requirements.
 
-To register a provider, open a pull request adding an entry to the enum in [`schemas/registry/providers.json`](schemas/registry/providers.json). Provider identifiers MUST be lowercase, start with a letter, and contain only alphanumeric characters and hyphens. Once merged, the value is considered stable and MUST NOT be renamed.
+To register a provider, open a pull request adding an entry to the `enum` in [`schemas/registry/providers.json`](schemas/registry/providers.json). Provider identifiers MUST be lowercase, start with a letter, and contain only alphanumeric characters and hyphens. Once merged, the value is considered stable and MUST NOT be renamed.

--- a/conformance/formats/domainid.json
+++ b/conformance/formats/domainid.json
@@ -1,0 +1,126 @@
+{
+  "description": "Test vectors for domainId URN serialization. Each valid case specifies the logical segments and the expected serialized string. SDKs MUST produce the expected string from the given segments and MUST parse the expected string back to the same segments (round-trip).",
+  "valid": [
+    {
+      "description": "GitHub PR, no provider-id",
+      "segments": {
+        "provider": "github",
+        "providerId": "",
+        "namespace": "xibz",
+        "groups": "cdevents-spec",
+        "type": "pr",
+        "resourceId": "42"
+      },
+      "expected": "cdevents:v0:github::xibz:cdevents-spec:pr:42"
+    },
+    {
+      "description": "GitHub PR with provider-id distinguishing two internal GitHub Enterprise deployments",
+      "segments": {
+        "provider": "github",
+        "providerId": "org-a-github",
+        "namespace": "xibz",
+        "groups": "cdevents-spec",
+        "type": "pr",
+        "resourceId": "42"
+      },
+      "expected": "cdevents:v0:github:org-a-github:xibz:cdevents-spec:pr:42"
+    },
+    {
+      "description": "Jira ticket, no provider-id",
+      "segments": {
+        "provider": "jira",
+        "providerId": "",
+        "namespace": "xibz",
+        "groups": "cdevents-project",
+        "type": "issue",
+        "resourceId": "PROJ-123"
+      },
+      "expected": "cdevents:v0:jira::xibz:cdevents-project:issue:PROJ-123"
+    },
+    {
+      "description": "GitLab MR with nested groups",
+      "segments": {
+        "provider": "gitlab",
+        "providerId": "",
+        "namespace": "my-company",
+        "groups": "platform/backend",
+        "type": "mr",
+        "resourceId": "99"
+      },
+      "expected": "cdevents:v0:gitlab::my-company:platform/backend:mr:99"
+    },
+    {
+      "description": "Datadog alert, no provider-id",
+      "segments": {
+        "provider": "datadog",
+        "providerId": "",
+        "namespace": "prod",
+        "groups": "api-monitors",
+        "type": "alert",
+        "resourceId": "98765"
+      },
+      "expected": "cdevents:v0:datadog::prod:api-monitors:alert:98765"
+    },
+    {
+      "description": "Docker artifact using PURL as resource id — provider, provider-id, namespace and groups all empty because registry is unknown",
+      "segments": {
+        "provider": "",
+        "providerId": "",
+        "namespace": "",
+        "groups": "",
+        "type": "artifact",
+        "resourceId": "pkg%3Adocker%2Fmyapp%401.0.0"
+      },
+      "expected": "cdevents:v0:::::artifact:pkg%3Adocker%2Fmyapp%401.0.0"
+    },
+    {
+      "description": "All optional segments empty — only type and resource id present; structurally valid",
+      "segments": {
+        "provider": "",
+        "providerId": "",
+        "namespace": "",
+        "groups": "",
+        "type": "pr",
+        "resourceId": "42"
+      },
+      "expected": "cdevents:v0:::::pr:42"
+    }
+  ],
+  "invalid": [
+    {
+      "description": "Missing provider-id segment (only 6 colons)",
+      "input": "cdevents:v0:github:xibz:cdevents-spec:pr:42",
+      "reason": "Segment count mismatch — provider-id segment omitted rather than left empty"
+    },
+    {
+      "description": "Empty type",
+      "input": "cdevents:v0:github::xibz:cdevents-spec::42",
+      "reason": "type is required and must not be empty"
+    },
+    {
+      "description": "Empty resource id",
+      "input": "cdevents:v0:github::xibz:cdevents-spec:pr:",
+      "reason": "resource id is required and must not be empty"
+    },
+    {
+      "description": "Leading slash in groups",
+      "input": "cdevents:v0:github::xibz:/cdevents-spec:pr:42",
+      "reason": "Leading '/' in groups is invalid"
+    },
+    {
+      "description": "Trailing slash in groups",
+      "input": "cdevents:v0:github::xibz:cdevents-spec/:pr:42",
+      "reason": "Trailing '/' in groups is invalid"
+    },
+    {
+      "description": "Wrong version",
+      "input": "cdevents:v1:github::xibz:cdevents-spec:pr:42",
+      "reason": "Only v0 is currently defined"
+    },
+    {
+      "description": "Wrong scheme prefix",
+      "input": "CDEvents:v0:github::xibz:cdevents-spec:pr:42",
+      "reason": "Scheme must be lowercase 'cdevents'"
+    }
+  ]
+}

--- a/links.md
+++ b/links.md
@@ -680,7 +680,9 @@ covering fan-out scenarios where one action triggers work across several systems
 
 ### CDEvents Domain IDs
 
-`domainId` values are URNs following this format:
+`domainId` values are URIs following this format:
+
+The `cdevents:` scheme prefix was chosen deliberately. The original design used a URN (`urn:`), but URN namespaces require formal registration — for example, `urn:github:...` would need to be registered by GitHub, and `urn:jira:...` by Atlassian. Using `urn:cdevents:...` for everything would raise the question of why a URN is needed at all if CDEvents is acting as the sole authority. A URI with a `cdevents:` scheme avoids these registry obligations while remaining a valid, parseable identifier under RFC 3986.
 
 ```
 cdevents:v0:<provider>:<provider-id>:<namespace>:<groups>:<type>:<resource id>
@@ -694,7 +696,7 @@ Segment values MUST reflect the exact canonical form as the value appears in the
 
 | Segment       | Required | Description                                                                                                    |
 |---------------|----------|----------------------------------------------------------------------------------------------------------------|
-| `version`     | yes      | The version of the `domainId` URN format (currently `v0`). This allows the format to evolve without breaking existing consumers. |
+| `version`     | yes      | The version of the `domainId` URI format (currently `v0`). This allows the format to evolve without breaking existing consumers. |
 | `provider`    | no       | A governed identifier for the tool or system type that owns the resource. When present, MUST match a known provider defined in [PROVIDERS.md](PROVIDERS.md). Free-form values are not permitted — without a governed list, the same tool would be referenced as `gh`, `github`, `GitHub`, etc., making cross-system queries unreliable. |
 | `provider-id` | no       | Identifies who owns and where a specific instance of the provider is running. This is entirely company or org-defined — CDEvents does not govern, assign, or interpret this value. It exists solely to distinguish between two instances of the same tool owned or operated by different teams or organizations (e.g. org A's internal GitHub Enterprise vs org B's). Producers and consumers within an organization MUST agree on the value out of band. MUST be URL-encoded when present. |
 | `namespace`   | no       | The top-level organizational unit within the provider's data model (e.g., a GitHub org, a Jira workspace). Producer-defined; not governed by CDEvents. MUST be URL-encoded when present. |
@@ -725,18 +727,39 @@ The `type` segment is a governed field. Producers MUST use one of the following
 values. This ensures interoperability — consumers can match and query by `type`
 without handling variations like `pull_request`, `PR`, or `pullrequest`.
 
-| Type          | Description                                                                        | `resource id` example         |
-|---------------|------------------------------------------------------------------------------------|-------------------------------|
-| `pr`          | A pull or merge request                                                            | `42` (PR number)              |
-| `commit`      | A source code commit                                                               | `abc123def456` (commit SHA)   |
-| `issue`       | An issue or ticket in a tracking system                                            | `1234` (issue number)         |
-| `branch`      | A source code branch                                                               | `main`, `feature/my-branch`   |
-| `tag`         | A source code tag or release                                                       | `v1.2.3`                      |
-| `definition`  | A named, reusable pipeline or workflow template                                    | `my-pipeline`                 |
-| `execution`   | A single run of a build, pipeline, workflow, or deployment                         | `789` (run number)            |
-| `artifact`    | A build artifact (binary, container image, package, etc.). The resource id SHOULD be a [PURL](https://github.com/package-url/purl-spec), URL-encoded. | `pkg%3Adocker%2Fmyapp%401.0.0` |
-| `environment` | A target deployment environment                                                    | `production`, `staging`       |
-| `alert`       | A monitoring or observability alert                                                | `98765` (alert ID)            |
+Most types are concrete and singular — `pr`, `commit`, `issue`, `branch`, `tag`,
+`artifact`, `environment`, `alert`, and `execution` each represent a single,
+unambiguous concept. If subtypes are added to these in the future (e.g.
+`execution.stage`), the bare type retains its original meaning and existing URNs
+remain valid — there is no migration cost.
+
+`definition` is treated differently. A bare `definition` could mean "a workflow
+definition" today, but if `definition.policy` or `definition.infrastructure` were
+added later, bare `definition` would become underspecified — consumers could no
+longer tell which kind of definition was intended without provider knowledge. To
+avoid this migration problem, `definition` is an abstract parent type that MUST
+NOT be used directly. Producers MUST always use a concrete subtype such as
+`definition.workflow`. New subtypes SHOULD follow the `definition.<kind>` naming
+convention and be proposed for addition to this list.
+
+`execution` specifically refers to a top-level run — a pipeline execution, workflow
+run, or build. Sub-level concepts such as stages, jobs, and steps are either
+covered by CDEvents events via `contextId` (if the system emits CDEvents) or are
+out of scope for `domainId`.
+
+| Type                   | Description                                                                                                    | `resource id` example          |
+|------------------------|----------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `pr`                   | A pull or merge request                                                                                        | `42` (PR number)              |
+| `commit`               | A source code commit                                                                                           | `abc123def456` (commit SHA)   |
+| `issue`                | An issue or ticket in a tracking system                                                                        | `1234` (issue number)         |
+| `branch`               | A source code branch                                                                                           | `main`, `feature/my-branch`   |
+| `tag`                  | A source code tag or release                                                                                   | `v1.2.3`                      |
+| `definition`           | Abstract parent. MUST NOT be used directly — use a concrete subtype.                                          | —                             |
+| `definition.workflow`  | An automation or pipeline definition — any template that describes a sequence of steps to be executed (e.g. a GitHub Actions workflow file, a CircleCI pipeline config, a Jenkinsfile). | `.github%2Fworkflows%2Fci.yml` |
+| `execution`            | A top-level run of a pipeline, workflow, or build. Always refers to the top-level execution — stages, jobs, and steps are out of scope. | `789` (run number)            |
+| `artifact`             | A build artifact (binary, container image, package, etc.). The resource id SHOULD be a [PURL](https://github.com/package-url/purl-spec), URL-encoded. | `pkg%3Adocker%2Fmyapp%401.0.0` |
+| `environment`          | A target deployment environment                                                                                | `production`, `staging`       |
+| `alert`                | A monitoring or observability alert                                                                            | `98765` (alert ID)            |
 
 If a resource does not fit any of the above types, it SHOULD be proposed for
 addition to this list before using a custom value.

--- a/links.md
+++ b/links.md
@@ -610,10 +610,6 @@ causality in `customData`, where it is unstructured and non-queryable.
 across system boundaries, regardless of whether the referenced system emits
 CDEvents.
 
-This is a transitional mechanism: as more systems adopt CDEvents, `domainId`
-links naturally migrate to `contextId` links. It is a bridge, not a
-permanent replacement.
-
 ### Event-to-Event vs Event-to-Resource Linking
 
 `contextId` and `domainId` represent two fundamentally different linking models.
@@ -657,7 +653,6 @@ domainId — many-to-many (N events, M resources)
    | domainId:        |  | domainId:         |  | domainId:        |
    | cdevents:v0:     |  | cdevents:v0:      |  | cdevents:v0:     |
    | github::xibz:... |  | github::xibz:...  |  | github::xibz:... |
-   | :pr:42           |  | :pr:42            |  | :pr:42           |
    +------------------+  +-------------------+  +------------------+
 
 
@@ -693,15 +688,19 @@ cdevents:v0:<provider>:<provider-id>:<namespace>:<groups>:<type>:<resource id>
 
 All segments MUST be present. If a segment has no value, it MUST be left empty rather than omitted (e.g. `cdevents:v0:github::xibz:...`). Omitting a segment shifts all following segments and introduces ambiguity.
 
-| Segment       | Description                                                                                                    |
-|---------------|----------------------------------------------------------------------------------------------------------------|
-| `version`     | The version of the `domainId` URN format (currently `v0`). This allows the format to evolve without breaking existing consumers. |
-| `provider`    | A governed identifier for the tool. Must match a known provider defined in the CDEvents provider list within this spec (e.g. `github`, `jira`, `datadog`). Free-form values are not permitted. |
-| `provider-id` | A company or org-defined identifier for the specific deployment of the provider (e.g. distinguishing one internal GitHub Enterprise from another). CDEvents does not govern this value — producers and consumers within an organization must agree on it. |
-| `namespace`   | The top-level organizational unit within the provider's data model (e.g., a GitHub org, a Jira workspace). Producer-defined; not governed by CDEvents. |
-| `groups`      | One or more organizational subdivisions within the namespace, separated by `/` to express nesting as defined by the provider's data model. For example, a GitHub repository is a single group (`my-repo`); a GitLab project nested under subgroups would be `group/subgroup/project`. Leading and trailing `/` are invalid. Producer-defined; not governed by CDEvents. |
-| `type`        | A governed resource type. Must be one of the values defined in [Common Resource Types](#common-resource-types) |
-| `resource id` | The publicly exposed identifier that end users see for this resource (e.g. a PR number, commit SHA, or ticket number). Must not be an internal or opaque system-generated ID. |
+Only `type` and `resource id` are required to be non-empty. All other segments are contextual — they narrow the identity of the resource but MAY be left empty when the information is not known or not applicable (e.g. an artifact whose provider registry is unknown).
+
+Segment values MUST reflect the exact canonical form as the value appears in the provider's system, before encoding is applied. When URL-encoding is required, percent-encoded hex digits MUST be uppercase (e.g. `%2F` not `%2f`).
+
+| Segment       | Required | Description                                                                                                    |
+|---------------|----------|----------------------------------------------------------------------------------------------------------------|
+| `version`     | yes      | The version of the `domainId` URN format (currently `v0`). This allows the format to evolve without breaking existing consumers. |
+| `provider`    | no       | A governed identifier for the tool or system type that owns the resource. When present, MUST match a known provider defined in [PROVIDERS.md](PROVIDERS.md). Free-form values are not permitted — without a governed list, the same tool would be referenced as `gh`, `github`, `GitHub`, etc., making cross-system queries unreliable. |
+| `provider-id` | no       | Identifies who owns and where a specific instance of the provider is running. This is entirely company or org-defined — CDEvents does not govern, assign, or interpret this value. It exists solely to distinguish between two instances of the same tool owned or operated by different teams or organizations (e.g. org A's internal GitHub Enterprise vs org B's). Producers and consumers within an organization MUST agree on the value out of band. MUST be URL-encoded when present. |
+| `namespace`   | no       | The top-level organizational unit within the provider's data model (e.g., a GitHub org, a Jira workspace). Producer-defined; not governed by CDEvents. MUST be URL-encoded when present. |
+| `groups`      | no       | One or more organizational subdivisions within the namespace, separated by `/` to express nesting as defined by the provider's data model. For example, a GitHub repository is a single group (`my-repo`); a GitLab project nested under subgroups would be `group/subgroup/project`. The `/` separator is structural and MUST NOT be encoded. Individual group segment values MUST be URL-encoded. Leading and trailing `/` are invalid. Producer-defined; not governed by CDEvents. |
+| `type`        | yes      | A governed resource type. MUST be one of the values defined in [Common Resource Types](#common-resource-types) |
+| `resource id` | yes      | The publicly exposed identifier that end users see for this resource (e.g. a PR number, commit SHA, ticket number, or PURL). MUST be URL-encoded. MUST NOT be an internal or opaque system-generated ID. |
 
 Examples:
 
@@ -711,6 +710,14 @@ Examples:
 - Jira ticket: `cdevents:v0:jira::xibz:cdevents-project:issue:12345`
 - Datadog alert: `cdevents:v0:datadog::prod:api-monitors:alert:98765`
 - GitLab MR (nested groups): `cdevents:v0:gitlab::my-company:platform/backend:mr:99`
+
+### Provider Validation
+
+The `provider` segment MUST match a known provider. CDEvents ships a default governed list of commonly used providers in [PROVIDERS.md](PROVIDERS.md), which serves as the baseline for validation.
+
+SDKs MUST support extending the provider list at initialization time, allowing organizations to register additional providers beyond the CDEvents default. Validation MUST check against the union of the CDEvents default list and any organization-supplied providers.
+
+When a `provider` value is not found in either list, the SDK SHOULD emit a warning. Whether to reject or allow the value SHOULD be configurable by the caller.
 
 ### Common Resource Types
 
@@ -727,7 +734,7 @@ without handling variations like `pull_request`, `PR`, or `pullrequest`.
 | `tag`         | A source code tag or release                                                       | `v1.2.3`                      |
 | `definition`  | A named, reusable pipeline or workflow template                                    | `my-pipeline`                 |
 | `execution`   | A single run of a build, pipeline, workflow, or deployment                         | `789` (run number)            |
-| `artifact`    | A build artifact (binary, container image, package, etc.)                          | `myapp:1.0.0`                 |
+| `artifact`    | A build artifact (binary, container image, package, etc.). The resource id SHOULD be a [PURL](https://github.com/package-url/purl-spec), URL-encoded. | `pkg%3Adocker%2Fmyapp%401.0.0` |
 | `environment` | A target deployment environment                                                    | `production`, `staging`       |
 | `alert`       | A monitoring or observability alert                                                | `98765` (alert ID)            |
 

--- a/links.md
+++ b/links.md
@@ -645,7 +645,7 @@ domainId — many-to-many (N events, M resources)
 
   Many events referencing one resource (domainId as container/grouping key):
 
-                         cdevents:github:xibz:repo:pr:42
+                         cdevents:v0:github:xibz:repo:pr:42
                          (external resource — container)
                                    ^
                                    |
@@ -655,7 +655,7 @@ domainId — many-to-many (N events, M resources)
    | CDEvent          |  | CDEvent           |  | CDEvent          |
    | build.started    |  | testrun.started   |  | service.deployed |
    | domainId:        |  | domainId:         |  | domainId:        |
-   | cdevents:github: |  | cdevents:github:  |  | cdevents:github: |
+   | cdevents:v0:github: |  | cdevents:v0:github:  |  | cdevents:v0:github: |
    | :repo:pr:42      |  | :repo:pr:42       |  | :repo:pr:42      |
    +------------------+  +-------------------+  +------------------+
 
@@ -665,18 +665,18 @@ domainId — many-to-many (N events, M resources)
    +----------------------------------+
    | CDEvent                          |
    | service.deployed                 |
-   | links: [                         +-----> cdevents:github:xibz:repo:pr:42
+   | links: [                         +-----> cdevents:v0:github:xibz:repo:pr:42
    |   { domainId:                    |
-   |     cdevents:github:...:pr:42 }, +-----> cdevents:jira:xibz:project:issue:12
+   |     cdevents:v0:github:...:pr:42 }, +-----> cdevents:v0:jira:xibz:project:issue:12
    |   { domainId:                    |
-   |     cdevents:jira:...:issue:12 },+-----> cdevents:circleci:xibz:pipeline:execution:789
+   |     cdevents:v0:jira:...:issue:12 },+-----> cdevents:v0:circleci:xibz:pipeline:execution:789
    |   { domainId:                    |
-   |     cdevents:circleci:...:789 }  |
+   |     cdevents:v0:circleci:...:789 }  |
    | ]                                |
    +----------------------------------+
 ```
 
-A consumer querying by `cdevents:github:xibz:repo:pr:42` gets back every CDEvent
+A consumer querying by `cdevents:v0:github:xibz:repo:pr:42` gets back every CDEvent
 that referenced that resource — build, test, deploy — without any single event
 needing to know about the others. A single event can simultaneously express
 causality across multiple external systems by listing multiple `domainId` links,
@@ -687,11 +687,12 @@ covering fan-out scenarios where one action triggers work across several systems
 `domainId` values are URNs following this format:
 
 ```
-cdevents:<service>:<namespace>:<instance>:<type>:<resource id>
+cdevents:v0:<service>:<namespace>:<instance>:<type>:<resource id>
 ```
 
 | Segment       | Description                                                                                                    |
 |---------------|----------------------------------------------------------------------------------------------------------------|
+| `version`     | The version of the `domainId` URN format (currently `v0`). This allows the format to evolve without breaking existing consumers. |
 | `service`     | A governed identifier for the system or tool. Must match a known entry in the CDEvents service registry or a shared identifier agreed upon by producers and consumers (e.g. `github`, `jira`, `datadog`). Free-form values are not permitted. |
 | `namespace`   | The org, account, or tenant within the service                                                                 |
 | `instance`    | The specific instance or environment within the namespace                                                      |
@@ -700,9 +701,9 @@ cdevents:<service>:<namespace>:<instance>:<type>:<resource id>
 
 Examples:
 
-- GitHub PR: `cdevents:github:xibz:repo:pr:42`
-- Jira ticket: `cdevents:jira:xibz:project:issue:12345`
-- Datadog alert: `cdevents:datadog:prod:monitor:alert:98765`
+- GitHub PR: `cdevents:v0:github:xibz:repo:pr:42`
+- Jira ticket: `cdevents:v0:jira:xibz:project:issue:12345`
+- Datadog alert: `cdevents:v0:datadog:prod:monitor:alert:98765`
 
 ### Common Resource Types
 
@@ -745,7 +746,7 @@ this.
       "linkType": "RELATION",
       "linkKind": "triggeredBy",
       "target": {
-        "domainId": "cdevents:github:xibz:repo:pr:42"
+        "domainId": "cdevents:v0:github:xibz:repo:pr:42"
       }
     }
   ]
@@ -761,7 +762,7 @@ this.
       "linkType": "RELATION",
       "linkKind": "triggeredBy",
       "target": {
-        "domainId": "cdevents:datadog:prod:monitor:alert:98765"
+        "domainId": "cdevents:v0:datadog:prod:monitor:alert:98765"
       }
     }
   ]
@@ -781,21 +782,21 @@ without requiring any system to know another system's internal context IDs:
       "linkType": "RELATION",
       "linkKind": "causedBy",
       "target": {
-        "domainId": "cdevents:circleci:xibz:pipeline:execution:789"
+        "domainId": "cdevents:v0:circleci:xibz:pipeline:execution:789"
       }
     },
     {
       "linkType": "RELATION",
       "linkKind": "causedBy",
       "target": {
-        "domainId": "cdevents:github:xibz:repo:commit:abc123def456"
+        "domainId": "cdevents:v0:github:xibz:repo:commit:abc123def456"
       }
     },
     {
       "linkType": "RELATION",
       "linkKind": "causedBy",
       "target": {
-        "domainId": "cdevents:github:xibz:repo:pr:42"
+        "domainId": "cdevents:v0:github:xibz:repo:pr:42"
       }
     }
   ]

--- a/links.md
+++ b/links.md
@@ -594,6 +594,228 @@ Relation links are used to add some context to certain events
   }
 }
 ```
+## Cross-Domain Linking with `domainId`
+
+### The Problem
+
+`contextId` requires the publisher to know the parent event's context ID.
+If the parent is not a CDEvent, there is no context ID to reference.
+
+For example, GitHub does not emit CDEvents today. A build event triggered by a
+GitHub PR cannot use `contextId` to link back to that PR — there is no CDEvent
+context ID to know. Without `domainId`, the only option is to bury that
+causality in `customData`, where it is unstructured and non-queryable.
+
+`domainId` provides a first-class way to express causality and relationships
+across system boundaries, regardless of whether the referenced system emits
+CDEvents.
+
+This is a transitional mechanism: as more systems adopt CDEvents, `domainId`
+links naturally migrate to `contextId` links. It is a bridge, not a
+permanent replacement.
+
+### Event-to-Event vs Event-to-Resource Linking
+
+`contextId` and `domainId` represent two fundamentally different linking models.
+
+`contextId` is **event-to-event**: it points to a single, specific CDEvent by
+its unique context ID. One event references exactly one other event.
+
+`domainId` is **many-to-many**: a `domainId` URN acts as a container. Many
+CDEvents can reference the same external resource, and a single CDEvent can
+reference many external resources. There is no requirement that any CDEvent
+know about the others referencing the same `domainId`.
+
+```plaintext
+contextId — event-to-event (1:1)
+
+  +--------------------+       contextId       +--------------------+
+  | CDEvent            |<----- "abc-123" ------| CDEvent            |
+  | id: "abc-123"      |                       | build.started      |
+  | change.merged      |                       | links: [{          |
+  +--------------------+                       |   target: {        |
+                                               |     contextId:     |
+                                               |     "abc-123"      |
+                                               |   }                |
+                                               | }]                 |
+                                               +--------------------+
+
+
+domainId — many-to-many (N events, M resources)
+
+  Many events referencing one resource (domainId as container/grouping key):
+
+                         cdevents:github:xibz:repo:pr:42
+                         (external resource — container)
+                                   ^
+                                   |
+              +--------------------+--------------------+
+              |                    |                    |
+   +----------+-------+  +---------+---------+  +------+-----------+
+   | CDEvent          |  | CDEvent           |  | CDEvent          |
+   | build.started    |  | testrun.started   |  | service.deployed |
+   | domainId:        |  | domainId:         |  | domainId:        |
+   | cdevents:github: |  | cdevents:github:  |  | cdevents:github: |
+   | :repo:pr:42      |  | :repo:pr:42       |  | :repo:pr:42      |
+   +------------------+  +-------------------+  +------------------+
+
+
+  One event referencing many resources (fan-out):
+
+   +----------------------------------+
+   | CDEvent                          |
+   | service.deployed                 |
+   | links: [                         +-----> cdevents:github:xibz:repo:pr:42
+   |   { domainId:                    |
+   |     cdevents:github:...:pr:42 }, +-----> cdevents:jira:xibz:project:issue:12
+   |   { domainId:                    |
+   |     cdevents:jira:...:issue:12 },+-----> cdevents:circleci:xibz:pipeline:execution:789
+   |   { domainId:                    |
+   |     cdevents:circleci:...:789 }  |
+   | ]                                |
+   +----------------------------------+
+```
+
+A consumer querying by `cdevents:github:xibz:repo:pr:42` gets back every CDEvent
+that referenced that resource — build, test, deploy — without any single event
+needing to know about the others. A single event can simultaneously express
+causality across multiple external systems by listing multiple `domainId` links,
+covering fan-out scenarios where one action triggers work across several systems.
+
+### CDEvents Domain IDs
+
+`domainId` values are URNs following this format:
+
+```
+cdevents:<service>:<namespace>:<instance>:<type>:<resource id>
+```
+
+| Segment       | Description                                                                                                    |
+|---------------|----------------------------------------------------------------------------------------------------------------|
+| `service`     | A governed identifier for the system or tool. Must match a known entry in the CDEvents service registry or a shared identifier agreed upon by producers and consumers (e.g. `github`, `jira`, `datadog`). Free-form values are not permitted. |
+| `namespace`   | The org, account, or tenant within the service                                                                 |
+| `instance`    | The specific instance or environment within the namespace                                                      |
+| `type`        | A governed resource type. Must be one of the values defined in [Common Resource Types](#common-resource-types) |
+| `resource id` | The publicly exposed identifier that end users see for this resource (e.g. a PR number, commit SHA, or ticket number). Must not be an internal or opaque system-generated ID. |
+
+Examples:
+
+- GitHub PR: `cdevents:github:xibz:repo:pr:42`
+- Jira ticket: `cdevents:jira:xibz:project:issue:12345`
+- Datadog alert: `cdevents:datadog:prod:monitor:alert:98765`
+
+### Common Resource Types
+
+The `type` segment is a governed field. Producers MUST use one of the following
+values. This ensures interoperability — consumers can match and query by `type`
+without handling variations like `pull_request`, `PR`, or `pullrequest`.
+
+| Type          | Description                                                                        | `resource id` example         |
+|---------------|------------------------------------------------------------------------------------|-------------------------------|
+| `pr`          | A pull or merge request                                                            | `42` (PR number)              |
+| `commit`      | A source code commit                                                               | `abc123def456` (commit SHA)   |
+| `issue`       | An issue or ticket in a tracking system                                            | `1234` (issue number)         |
+| `branch`      | A source code branch                                                               | `main`, `feature/my-branch`   |
+| `tag`         | A source code tag or release                                                       | `v1.2.3`                      |
+| `definition`  | A named, reusable pipeline or workflow template                                    | `my-pipeline`                 |
+| `execution`   | A single run of a build, pipeline, workflow, or deployment                         | `789` (run number)            |
+| `artifact`    | A build artifact (binary, container image, package, etc.)                          | `myapp:1.0.0`                 |
+| `environment` | A target deployment environment                                                    | `production`, `staging`       |
+| `alert`       | A monitoring or observability alert                                                | `98765` (alert ID)            |
+
+If a resource does not fit any of the above types, it SHOULD be proposed for
+addition to this list before using a custom value.
+
+### Usage in Relation Links
+
+`domainId` can be used in place of `contextId` in the `source` and `target`
+fields of a `RELATION` link. Both embedded and standalone relation links support
+this.
+
+**Example: Build triggered by a GitHub PR**
+
+```json
+{
+  "context": {
+    "id": "build-event-789",
+    "chainId": "d0be0005-cca7-4175-8fe3-f64d2f27bc01"
+  },
+  "links": [
+    {
+      "linkType": "RELATION",
+      "linkKind": "triggeredBy",
+      "target": {
+        "domainId": "cdevents:github:xibz:repo:pr:42"
+      }
+    }
+  ]
+}
+```
+
+**Example: Rollback pipeline triggered by a Datadog alert**
+
+```json
+{
+  "links": [
+    {
+      "linkType": "RELATION",
+      "linkKind": "triggeredBy",
+      "target": {
+        "domainId": "cdevents:datadog:prod:monitor:alert:98765"
+      }
+    }
+  ]
+}
+```
+
+**Example: Deployment failure with full cross-domain causality**
+
+A deployment failure can link back to its causes across multiple systems,
+without requiring any system to know another system's internal context IDs:
+
+```json
+{
+  "context": { "id": "deploy-event-999" },
+  "links": [
+    {
+      "linkType": "RELATION",
+      "linkKind": "causedBy",
+      "target": {
+        "domainId": "cdevents:circleci:xibz:pipeline:execution:789"
+      }
+    },
+    {
+      "linkType": "RELATION",
+      "linkKind": "causedBy",
+      "target": {
+        "domainId": "cdevents:github:xibz:repo:commit:abc123def456"
+      }
+    },
+    {
+      "linkType": "RELATION",
+      "linkKind": "causedBy",
+      "target": {
+        "domainId": "cdevents:github:xibz:repo:pr:42"
+      }
+    }
+  ]
+}
+```
+
+Consumers can query directly by `domainId` URN without parsing `customData` or
+needing to know the context IDs of external systems.
+
+### When to Use `contextId` vs `domainId`
+
+| Scenario | Use |
+|----------|-----|
+| Linking to another CDEvent whose context ID is known | `contextId` |
+| Linking to a system that does not emit CDEvents | `domainId` |
+| Linking to a CDEvent but context ID is not available | `domainId` as a fallback |
+
+Each system uses what it knows: `contextId` for events within the CDEvents
+ecosystem, and `domainId` URNs for anything outside it.
+
 ### Scalability
 
 Scalability is one of the bigger goals in this proposal and we wanted to ensure

--- a/links.md
+++ b/links.md
@@ -645,7 +645,7 @@ domainId — many-to-many (N events, M resources)
 
   Many events referencing one resource (domainId as container/grouping key):
 
-                         cdevents:v0:github:xibz:repo:pr:42
+                         cdevents:v0:github::xibz:cdevents-spec:pr:42
                          (external resource — container)
                                    ^
                                    |
@@ -655,8 +655,9 @@ domainId — many-to-many (N events, M resources)
    | CDEvent          |  | CDEvent           |  | CDEvent          |
    | build.started    |  | testrun.started   |  | service.deployed |
    | domainId:        |  | domainId:         |  | domainId:        |
-   | cdevents:v0:github: |  | cdevents:v0:github:  |  | cdevents:v0:github: |
-   | :repo:pr:42      |  | :repo:pr:42       |  | :repo:pr:42      |
+   | cdevents:v0:     |  | cdevents:v0:      |  | cdevents:v0:     |
+   | github::xibz:... |  | github::xibz:...  |  | github::xibz:... |
+   | :pr:42           |  | :pr:42            |  | :pr:42           |
    +------------------+  +-------------------+  +------------------+
 
 
@@ -665,18 +666,18 @@ domainId — many-to-many (N events, M resources)
    +----------------------------------+
    | CDEvent                          |
    | service.deployed                 |
-   | links: [                         +-----> cdevents:v0:github:xibz:repo:pr:42
+   | links: [                         +-----> cdevents:v0:github::xibz:cdevents-spec:pr:42
    |   { domainId:                    |
-   |     cdevents:v0:github:...:pr:42 }, +-----> cdevents:v0:jira:xibz:project:issue:12
+   |     cdevents:v0:github::xibz:... }, +-----> cdevents:v0:jira::xibz:cdevents-project:issue:12
    |   { domainId:                    |
-   |     cdevents:v0:jira:...:issue:12 },+-----> cdevents:v0:circleci:xibz:pipeline:execution:789
+   |     cdevents:v0:jira::xibz:...  },  +-----> cdevents:v0:circleci::xibz:my-pipeline:execution:789
    |   { domainId:                    |
-   |     cdevents:v0:circleci:...:789 }  |
+   |     cdevents:v0:circleci::xibz:... }|
    | ]                                |
    +----------------------------------+
 ```
 
-A consumer querying by `cdevents:v0:github:xibz:repo:pr:42` gets back every CDEvent
+A consumer querying by `cdevents:v0:github::xibz:cdevents-spec:pr:42` gets back every CDEvent
 that referenced that resource — build, test, deploy — without any single event
 needing to know about the others. A single event can simultaneously express
 causality across multiple external systems by listing multiple `domainId` links,
@@ -687,23 +688,29 @@ covering fan-out scenarios where one action triggers work across several systems
 `domainId` values are URNs following this format:
 
 ```
-cdevents:v0:<service>:<namespace>:<instance>:<type>:<resource id>
+cdevents:v0:<provider>:<provider-id>:<namespace>:<groups>:<type>:<resource id>
 ```
+
+All segments MUST be present. If a segment has no value, it MUST be left empty rather than omitted (e.g. `cdevents:v0:github::xibz:...`). Omitting a segment shifts all following segments and introduces ambiguity.
 
 | Segment       | Description                                                                                                    |
 |---------------|----------------------------------------------------------------------------------------------------------------|
 | `version`     | The version of the `domainId` URN format (currently `v0`). This allows the format to evolve without breaking existing consumers. |
-| `service`     | A governed identifier for the system or tool. Must match a known entry in the CDEvents service registry or a shared identifier agreed upon by producers and consumers (e.g. `github`, `jira`, `datadog`). Free-form values are not permitted. |
-| `namespace`   | The org, account, or tenant within the service                                                                 |
-| `instance`    | The specific instance or environment within the namespace                                                      |
+| `provider`    | A governed identifier for the tool. Must match a known provider defined in the CDEvents provider list within this spec (e.g. `github`, `jira`, `datadog`). Free-form values are not permitted. |
+| `provider-id` | A company or org-defined identifier for the specific deployment of the provider (e.g. distinguishing one internal GitHub Enterprise from another). CDEvents does not govern this value — producers and consumers within an organization must agree on it. |
+| `namespace`   | The top-level organizational unit within the provider's data model (e.g., a GitHub org, a Jira workspace). Producer-defined; not governed by CDEvents. |
+| `groups`      | One or more organizational subdivisions within the namespace, separated by `/` to express nesting as defined by the provider's data model. For example, a GitHub repository is a single group (`my-repo`); a GitLab project nested under subgroups would be `group/subgroup/project`. Leading and trailing `/` are invalid. Producer-defined; not governed by CDEvents. |
 | `type`        | A governed resource type. Must be one of the values defined in [Common Resource Types](#common-resource-types) |
 | `resource id` | The publicly exposed identifier that end users see for this resource (e.g. a PR number, commit SHA, or ticket number). Must not be an internal or opaque system-generated ID. |
 
 Examples:
 
-- GitHub PR: `cdevents:v0:github:xibz:repo:pr:42`
-- Jira ticket: `cdevents:v0:jira:xibz:project:issue:12345`
-- Datadog alert: `cdevents:v0:datadog:prod:monitor:alert:98765`
+- GitHub PR (no provider-id): `cdevents:v0:github::xibz:cdevents-spec:pr:42`
+- GitHub PR (org A's internal GitHub Enterprise): `cdevents:v0:github:org-a-github:xibz:cdevents-spec:pr:42`
+- GitHub PR (org B's internal GitHub Enterprise): `cdevents:v0:github:org-b-github:xibz:cdevents-spec:pr:42`
+- Jira ticket: `cdevents:v0:jira::xibz:cdevents-project:issue:12345`
+- Datadog alert: `cdevents:v0:datadog::prod:api-monitors:alert:98765`
+- GitLab MR (nested groups): `cdevents:v0:gitlab::my-company:platform/backend:mr:99`
 
 ### Common Resource Types
 
@@ -746,7 +753,7 @@ this.
       "linkType": "RELATION",
       "linkKind": "triggeredBy",
       "target": {
-        "domainId": "cdevents:v0:github:xibz:repo:pr:42"
+        "domainId": "cdevents:v0:github::xibz:cdevents-spec:pr:42"
       }
     }
   ]
@@ -762,7 +769,7 @@ this.
       "linkType": "RELATION",
       "linkKind": "triggeredBy",
       "target": {
-        "domainId": "cdevents:v0:datadog:prod:monitor:alert:98765"
+        "domainId": "cdevents:v0:datadog::prod:api-monitors:alert:98765"
       }
     }
   ]
@@ -782,21 +789,21 @@ without requiring any system to know another system's internal context IDs:
       "linkType": "RELATION",
       "linkKind": "causedBy",
       "target": {
-        "domainId": "cdevents:v0:circleci:xibz:pipeline:execution:789"
+        "domainId": "cdevents:v0:circleci::xibz:my-pipeline:execution:789"
       }
     },
     {
       "linkType": "RELATION",
       "linkKind": "causedBy",
       "target": {
-        "domainId": "cdevents:v0:github:xibz:repo:commit:abc123def456"
+        "domainId": "cdevents:v0:github::xibz:cdevents-spec:commit:abc123def456"
       }
     },
     {
       "linkType": "RELATION",
       "linkKind": "causedBy",
       "target": {
-        "domainId": "cdevents:v0:github:xibz:repo:pr:42"
+        "domainId": "cdevents:v0:github::xibz:cdevents-spec:pr:42"
       }
     }
   ]

--- a/schemas/links/domainid.json
+++ b/schemas/links/domainid.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/links/domainid",
+  "description": "A canonical CDEvents domain ID URN that identifies a resource in an external system that does not emit CDEvents. The provider-id, namespace, individual group segment values within groups, and resource id MUST be URL-encoded. The '/' separator between group segments is structural and MUST NOT be encoded. The provider segment MUST be validated separately against ../registry/providers.json.",
+  "type": "string",
+  "format": "uri-reference",
+  "pattern": "^cdevents:v0:[^:]*:[^:]*:[^:]*:([^:/]([^:]*[^:/])?)?:[^:]+:.+$",
+  "examples": [
+    "cdevents:v0:github::xibz:cdevents-spec:pr:42",
+    "cdevents:v0:github:org-a-github:xibz:cdevents-spec:pr:42",
+    "cdevents:v0:jira::xibz:cdevents-project:issue:PROJ-123",
+    "cdevents:v0:datadog::prod:api-monitors:alert:98765",
+    "cdevents:v0:gitlab::my-company:platform/backend:mr:99"
+  ]
+}

--- a/schemas/links/embeddedlinkend.json
+++ b/schemas/links/embeddedlinkend.json
@@ -15,10 +15,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "tags": {

--- a/schemas/links/embeddedlinkpath.json
+++ b/schemas/links/embeddedlinkpath.json
@@ -15,10 +15,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "tags": {

--- a/schemas/links/embeddedlinkrelation.json
+++ b/schemas/links/embeddedlinkrelation.json
@@ -19,8 +19,16 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
-      }
+      },
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
+      ]
     },
     "tags": {
       "type": "object",

--- a/schemas/links/embeddedlinkrelation.json
+++ b/schemas/links/embeddedlinkrelation.json
@@ -21,8 +21,7 @@
           "minLength": 1
         },
         "domainId": {
-          "type": "string",
-          "format": "uri-reference"
+          "$ref": "domainid.json"
         }
       },
       "anyOf": [

--- a/schemas/links/embeddedlinkrelation.json
+++ b/schemas/links/embeddedlinkrelation.json
@@ -21,7 +21,7 @@
           "minLength": 1
         },
         "domainId": {
-          "$ref": "domainid.json"
+          "$ref": "https://cdevents.dev/0.6.0-draft/schema/links/domainid"
         }
       },
       "anyOf": [

--- a/schemas/links/linkend.json
+++ b/schemas/links/linkend.json
@@ -25,10 +25,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "end": {
@@ -38,10 +43,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "tags": {

--- a/schemas/links/linkpath.json
+++ b/schemas/links/linkpath.json
@@ -22,10 +22,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "to": {
@@ -34,10 +39,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "tags": {

--- a/schemas/links/linkrelation.json
+++ b/schemas/links/linkrelation.json
@@ -28,10 +28,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "target": {
@@ -41,10 +46,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "tags": {

--- a/schemas/links/linkrelation.json
+++ b/schemas/links/linkrelation.json
@@ -30,7 +30,7 @@
           "minLength": 1
         },
         "domainId": {
-          "$ref": "domainid.json"
+          "$ref": "https://cdevents.dev/0.6.0-draft/schema/links/domainid"
         }
       },
       "anyOf": [
@@ -47,7 +47,7 @@
           "minLength": 1
         },
         "domainId": {
-          "$ref": "domainid.json"
+          "$ref": "https://cdevents.dev/0.6.0-draft/schema/links/domainid"
         }
       },
       "anyOf": [

--- a/schemas/links/linkrelation.json
+++ b/schemas/links/linkrelation.json
@@ -30,8 +30,7 @@
           "minLength": 1
         },
         "domainId": {
-          "type": "string",
-          "format": "uri-reference"
+          "$ref": "domainid.json"
         }
       },
       "anyOf": [
@@ -48,8 +47,7 @@
           "minLength": 1
         },
         "domainId": {
-          "type": "string",
-          "format": "uri-reference"
+          "$ref": "domainid.json"
         }
       },
       "anyOf": [

--- a/schemas/links/linkstart.json
+++ b/schemas/links/linkstart.json
@@ -25,10 +25,15 @@
         "contextId": {
           "type": "string",
           "minLength": 1
+        },
+        "domainId": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
-      "required": [
-        "contextId"
+      "anyOf": [
+        { "required": ["contextId"] },
+        { "required": ["domainId"] }
       ]
     },
     "tags": {

--- a/schemas/registry/providers.json
+++ b/schemas/registry/providers.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/links/providers",
+  "description": "Registry of known CDEvents domainId provider identifiers. Known providers are listed below. To register a new provider, submit a pull request adding an entry to the enum and the PROVIDERS.md table.",
+  "type": "string",
+  "pattern": "^[a-z][a-z0-9-]*$",
+  "enum": [
+    "artifactory",
+    "argo",
+    "bitbucket",
+    "circleci",
+    "datadog",
+    "docker",
+    "gitea",
+    "github",
+    "gitlab",
+    "grafana",
+    "jenkins",
+    "jira",
+    "linear",
+    "nexus",
+    "pagerduty",
+    "tekton"
+  ]
+}

--- a/tools/validate.js
+++ b/tools/validate.js
@@ -30,7 +30,7 @@ const EXAMPLES_FOLDER = join(ROOT, "conformance");
 const SCHEMAS_FOLDER = join(ROOT, "schemas");
 const EMBEDDED_LINKS_SCHEMAS_PATTERN = join(
   ROOT,
-  "schemas/links/embedded*.json",
+  "schemas/links/*.json",
 );
 
 // Helper function to load JSON file
@@ -54,7 +54,7 @@ function createAjv() {
   return ajv;
 }
 
-// Load embedded links schemas
+// Load links schemas for use as references
 function loadEmbeddedLinksSchemas() {
   const schemas = [];
   const files = globSync(EMBEDDED_LINKS_SCHEMAS_PATTERN);
@@ -78,9 +78,8 @@ function testSchemas() {
   for (const schemaFile of eventSchemaFiles) {
     try {
       const ajv = createAjv();
-      // Add embedded links schemas as references
-      for (const embeddedSchema of embeddedLinksSchemas) {
-        ajv.addSchema(embeddedSchema);
+      for (const schema of embeddedLinksSchemas) {
+        ajv.addSchema(schema);
       }
       const schema = loadJSON(schemaFile);
       ajv.compile(schema);
@@ -97,6 +96,11 @@ function testSchemas() {
   for (const schemaFile of linkSchemaFiles) {
     try {
       const ajv = createAjv();
+      for (const refSchema of embeddedLinksSchemas) {
+        if (!refSchema.$id?.includes("/links/link")) {
+          ajv.addSchema(refSchema);
+        }
+      }
       const schema = loadJSON(schemaFile);
       ajv.compile(schema);
     } catch (error) {
@@ -109,8 +113,8 @@ function testSchemas() {
   numSchemas += 1;
   try {
     const ajv = createAjv();
-    for (const embeddedSchema of embeddedLinksSchemas) {
-      ajv.addSchema(embeddedSchema);
+    for (const schema of embeddedLinksSchemas) {
+      ajv.addSchema(schema);
     }
     const customSchema = loadJSON(join(ROOT, "custom/schema.json"));
     ajv.compile(customSchema);


### PR DESCRIPTION
This change updates all link schemas (START, END, RELATION, and embedded variants) to allow references to either a CDEvent contextId, a domainId, or both.

Previously, links could only reference event context IDs. This limited cross-system connectivity and encouraged embedding execution identifiers in customData purely for graph reconstruction.

By allowing domainId alongside contextId:
- Links can represent relationships between domain executions (e.g., pipelinerun) as well as individual events.
- Connectivity metadata no longer needs to be embedded in event payloads.
- Chain-first modeling constraints are relaxed, enabling relation-first graph modeling.
- The change remains backward compatible.

At least one of contextId or domainId is now required for link endpoints. AdditionalProperties are restricted to prevent schema drift.

This preserves existing semantics while improving flexibility and reducing customData pollution.