### PR TITLE
feat!: merge `subject.source` into `subject.id`

### DIFF
--- a/cloudevents-binding.md
+++ b/cloudevents-binding.md
@@ -114,8 +114,7 @@ Content-Length: nnnn
          "task": "my-task",
          "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123"
          "pipelineRun": {
-            "id": "/somewherelse/pipelinerun-123",
-            "source": "/staging/jenkins/"
+            "id": "/staging/jenkins/somewherelse/pipelinerun-123"
          }
       }
    }

--- a/conformance/artifact_deleted.json
+++ b/conformance/artifact_deleted.json
@@ -40,7 +40,6 @@
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
-    "source": "/event/source/123",
     "content": {
       "user": "mybot-myapp"
     }

--- a/conformance/artifact_downloaded.json
+++ b/conformance/artifact_downloaded.json
@@ -40,7 +40,6 @@
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
-    "source": "/event/source/123",
     "content": {
       "user": "mybot-myapp"
     }

--- a/conformance/artifact_packaged.json
+++ b/conformance/artifact_packaged.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
-    "source": "/event/source/123",
     "content": {
       "change": {
-        "id": "myChange123",
-        "source": "my-git.example/an-org/a-repo"
+        "id": "my-git.example/an-org/a-repo/myChange123"
       },
       "sbom": {
         "uri": "https://sbom.repo/myorg/234fd47e07d1004f0aed9c.sbom"

--- a/conformance/artifact_published.json
+++ b/conformance/artifact_published.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
-    "source": "/event/source/123",
     "content": {
       "sbom": {
         "uri": "https://sbom.repo/myorg/234fd47e07d1004f0aed9c.sbom"

--- a/conformance/artifact_signed.json
+++ b/conformance/artifact_signed.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c",
-    "source": "/event/source/123",
     "content": {
       "signature": "MEYCIQCBT8U5ypDXWCjlNKfzTV4KH516/SK13NZSh8znnSMNkQIhAJ3XiQlc9PM1KyjITcZXHotdMB+J3NGua5T/yshmiPmp"
     }

--- a/conformance/branch_created.json
+++ b/conformance/branch_created.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/branch_deleted.json
+++ b/conformance/branch_deleted.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/build_finished.json
+++ b/conformance/build_finished.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427"
     }

--- a/conformance/build_queued.json
+++ b/conformance/build_queued.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {}
   }
 }

--- a/conformance/build_started.json
+++ b/conformance/build_started.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {}
   }
 }

--- a/conformance/change_abandoned.json
+++ b/conformance/change_abandoned.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/change_created.json
+++ b/conformance/change_created.json
@@ -41,12 +41,10 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "description": "This PR address a bug from a recent PR",
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/change_merged.json
+++ b/conformance/change_merged.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/change_reviewed.json
+++ b/conformance/change_reviewed.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/change_updated.json
+++ b/conformance/change_updated.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "repository": {
-        "id": "TestRepo/TestOrg",
-        "source": "https://example.org"
+        "id": "https://example.org/TestRepo/TestOrg"
       }
     }
   }

--- a/conformance/environment_created.json
+++ b/conformance/environment_created.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "name": "testEnv",
       "uri": "https://example.org/testEnv"

--- a/conformance/environment_deleted.json
+++ b/conformance/environment_deleted.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "name": "testEnv"
     }

--- a/conformance/environment_modified.json
+++ b/conformance/environment_modified.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "name": "testEnv",
       "uri": "https://example.org/testEnv"

--- a/conformance/incident_detected.json
+++ b/conformance/incident_detected.json
@@ -41,16 +41,13 @@
   },
   "subject": {
     "id": "incident-123",
-    "source": "/monitoring/prod1",
     "content": {
       "description": "Response time above threshold of 100ms",
       "environment": {
-        "id": "prod1",
-        "source": "/iaas/geo1"
+        "id": "/iaas/geo1/prod1"
       },
       "service": {
-        "id": "myApp",
-        "source": "/clusterA/namespaceB"
+        "id": "/clusterA/namespaceB/myApp"
       },
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427"
     }

--- a/conformance/incident_reported.json
+++ b/conformance/incident_reported.json
@@ -41,16 +41,13 @@
   },
   "subject": {
     "id": "incident-123",
-    "source": "/monitoring/prod1",
     "content": {
       "description": "Response time above threshold of 100ms",
       "environment": {
-        "id": "prod1",
-        "source": "/iaas/geo1"
+        "id": "/iaas/geo1/prod1"
       },
       "service": {
-        "id": "myApp",
-        "source": "/clusterA/namespaceB"
+        "id": "/clusterA/namespaceB/myApp"
       },
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
       "ticketURI": "https://my-issues.example/incidents/ticket-345"

--- a/conformance/incident_resolved.json
+++ b/conformance/incident_resolved.json
@@ -41,16 +41,13 @@
   },
   "subject": {
     "id": "incident-123",
-    "source": "/monitoring/prod1",
     "content": {
       "description": "Response time restored below 100ms",
       "environment": {
-        "id": "prod1",
-        "source": "/iaas/geo1"
+        "id": "/iaas/geo1/prod1"
       },
       "service": {
-        "id": "myApp",
-        "source": "/clusterA/namespaceB"
+        "id": "/clusterA/namespaceB/myApp"
       },
       "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93439"
     }

--- a/conformance/pipelinerun_finished.json
+++ b/conformance/pipelinerun_finished.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123",

--- a/conformance/pipelinerun_queued.json
+++ b/conformance/pipelinerun_queued.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"

--- a/conformance/pipelinerun_started.json
+++ b/conformance/pipelinerun_started.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"

--- a/conformance/repository_created.json
+++ b/conformance/repository_created.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",

--- a/conformance/repository_deleted.json
+++ b/conformance/repository_deleted.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",

--- a/conformance/repository_modified.json
+++ b/conformance/repository_modified.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "name": "TestRepo",
       "owner": "TestOrg",

--- a/conformance/service_deployed.json
+++ b/conformance/service_deployed.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_published.json
+++ b/conformance/service_published.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_removed.json
+++ b/conformance/service_removed.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_rolledback.json
+++ b/conformance/service_rolledback.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/service_upgraded.json
+++ b/conformance/service_upgraded.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
         "id": "test123"

--- a/conformance/taskrun_finished.json
+++ b/conformance/taskrun_finished.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "taskName": "myTask",
       "uri": "https://www.example.com/mySubject123",

--- a/conformance/taskrun_started.json
+++ b/conformance/taskrun_started.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "taskName": "myTask",
       "uri": "https://www.example.com/mySubject123",

--- a/conformance/testcaserun_finished.json
+++ b/conformance/testcaserun_finished.json
@@ -41,12 +41,10 @@
   },
   "subject": {
     "id": "myTestCaseRun123",
-    "source": "/event/source/123",
     "content": {
       "outcome": "success",
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testCase": {
         "id": "92834723894",

--- a/conformance/testcaserun_queued.json
+++ b/conformance/testcaserun_queued.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "myTestCaseRun123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testCase": {
         "id": "92834723894",

--- a/conformance/testcaserun_skipped.json
+++ b/conformance/testcaserun_skipped.json
@@ -40,16 +40,13 @@
   },
   "subject": {
     "id": "myTestCaseRun123",
-    "source": "/event/source/123",
     "content": {
       "reason": "Not running in this environment",
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testSuiteRun": {
-        "id": "test-suite-111",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/test-suite-111"
       },
       "testCase": {
         "id": "92834723894",

--- a/conformance/testcaserun_started.json
+++ b/conformance/testcaserun_started.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "myTestCaseRun123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testCase": {
         "id": "92834723894",

--- a/conformance/testoutput_published.json
+++ b/conformance/testoutput_published.json
@@ -41,13 +41,11 @@
   },
   "subject": {
     "id": "testrunreport-12123",
-    "source": "/event/source/testrunreport-12123",
     "content": {
       "outputType": "video",
       "format": "video/quicktime",
       "testCaseRun": {
-        "id": "myTestCaseRun123",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/myTestCaseRun123"
       }
     }
   }

--- a/conformance/testsuiterun_finished.json
+++ b/conformance/testsuiterun_finished.json
@@ -41,14 +41,12 @@
   },
   "subject": {
     "id": "myTestSuiteRun123",
-    "source": "/event/source/123",
     "content": {
       "outcome": "failure",
       "severity": "critical",
       "reason": "Host 123.34.23.32 not found",
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testSuite": {
         "id": "92834723894",

--- a/conformance/testsuiterun_queued.json
+++ b/conformance/testsuiterun_queued.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "myTestSuiteRun123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testSuite": {
         "id": "92834723894",

--- a/conformance/testsuiterun_started.json
+++ b/conformance/testsuiterun_started.json
@@ -41,11 +41,9 @@
   },
   "subject": {
     "id": "myTestSuiteRun123",
-    "source": "/event/source/123",
     "content": {
       "environment": {
-        "id": "dev",
-        "source": "testkube-dev-123"
+        "id": "/testkube-dev-123/dev"
       },
       "testSuite": {
         "id": "92834723894",

--- a/conformance/ticket_closed.json
+++ b/conformance/ticket_closed.json
@@ -40,7 +40,6 @@
   },
   "subject": {
     "id": "ticket-123",
-    "source": "/ticketing/system",
     "content": {
       "summary": "New CVE-123 detected",
       "ticketType": "task",

--- a/conformance/ticket_created.json
+++ b/conformance/ticket_created.json
@@ -40,7 +40,6 @@
   },
   "subject": {
     "id": "ticket-123",
-    "source": "/ticketing/system",
     "content": {
       "summary": "New CVE-123 detected",
       "ticketType": "task",

--- a/conformance/ticket_updated.json
+++ b/conformance/ticket_updated.json
@@ -40,7 +40,6 @@
   },
   "subject": {
     "id": "ticket-123",
-    "source": "/ticketing/system",
     "content": {
       "summary": "New CVE-123 detected",
       "ticketType": "task",

--- a/custom/conformance.json
+++ b/custom/conformance.json
@@ -41,7 +41,6 @@
   },
   "subject": {
     "id": "pkg:resource/name@234fd47e07d1004f0aed9c",
-    "source": "/event/source/123",
     "content": {
       "user": "mybot-myapp",
       "description": "a useful resource",

--- a/custom/schema.json
+++ b/custom/schema.json
@@ -52,12 +52,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "type": "object",

--- a/links.md
+++ b/links.md
@@ -181,7 +181,6 @@ systems to act accordingly based off the ending notation.
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"
@@ -215,7 +214,6 @@ further, we can allow for a path link between `pipelinerun.queued` to the
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"
@@ -380,8 +378,7 @@ help explain the overall flow using payloads from CDEvents.
     "type": "change",
     "content": {
       "repository": {
-        "id": "cdevents/service",
-        "source": "https://github.com/cdevents/service/pull/1234"
+        "id": "https://github.com/cdevents/service"
       }
     }
   }
@@ -426,7 +423,6 @@ sender generates this id.
   },
   "subject": {
     "id": "mySubject123",
-    "source": "/event/source/123",
     "content": {
       "pipelineName": "myPipeline",
       "uri": "https://www.example.com/mySubject123"

--- a/schemas/artifactdeleted.json
+++ b/schemas/artifactdeleted.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/artifactdownloaded.json
+++ b/schemas/artifactdownloaded.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/artifactpackaged.json
+++ b/schemas/artifactpackaged.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/artifactpublished.json
+++ b/schemas/artifactpublished.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/artifactsigned.json
+++ b/schemas/artifactsigned.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/branchcreated.json
+++ b/schemas/branchcreated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/branchdeleted.json
+++ b/schemas/branchdeleted.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/buildfinished.json
+++ b/schemas/buildfinished.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/buildqueued.json
+++ b/schemas/buildqueued.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {},

--- a/schemas/buildstarted.json
+++ b/schemas/buildstarted.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {},

--- a/schemas/changeabandoned.json
+++ b/schemas/changeabandoned.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changecreated.json
+++ b/schemas/changecreated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -73,11 +69,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changemerged.json
+++ b/schemas/changemerged.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changereviewed.json
+++ b/schemas/changereviewed.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/changeupdated.json
+++ b/schemas/changeupdated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/environmentcreated.json
+++ b/schemas/environmentcreated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/environmentdeleted.json
+++ b/schemas/environmentdeleted.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/environmentmodified.json
+++ b/schemas/environmentmodified.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/incidentdetected.json
+++ b/schemas/incidentdetected.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -72,11 +68,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,
@@ -90,11 +81,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/incidentreported.json
+++ b/schemas/incidentreported.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -72,11 +68,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,
@@ -95,11 +86,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/incidentresolved.json
+++ b/schemas/incidentresolved.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -72,11 +68,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,
@@ -90,11 +81,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/pipelinerunfinished.json
+++ b/schemas/pipelinerunfinished.json
@@ -47,12 +47,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/pipelinerunqueued.json
+++ b/schemas/pipelinerunqueued.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/pipelinerunstarted.json
+++ b/schemas/pipelinerunstarted.json
@@ -59,12 +59,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/repositorycreated.json
+++ b/schemas/repositorycreated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/repositorydeleted.json
+++ b/schemas/repositorydeleted.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/repositorymodified.json
+++ b/schemas/repositorymodified.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -69,11 +65,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -76,11 +72,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/taskrunstarted.json
+++ b/schemas/taskrunstarted.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {
@@ -76,11 +72,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testcaserunfinished.json
+++ b/schemas/testcaserunfinished.json
@@ -69,11 +69,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testcaserunqueued.json
+++ b/schemas/testcaserunqueued.json
@@ -85,11 +85,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testcaserunskipped.json
+++ b/schemas/testcaserunskipped.json
@@ -69,11 +69,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testcaserunstarted.json
+++ b/schemas/testcaserunstarted.json
@@ -85,11 +85,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testsuiterunfinished.json
+++ b/schemas/testsuiterunfinished.json
@@ -58,11 +58,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testsuiterunqueued.json
+++ b/schemas/testsuiterunqueued.json
@@ -85,11 +85,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/testsuiterunstarted.json
+++ b/schemas/testsuiterunstarted.json
@@ -85,11 +85,6 @@
                 "id": {
                   "type": "string",
                   "minLength": 1
-                },
-                "source": {
-                  "type": "string",
-                  "minLength": 1,
-                  "format": "uri-reference"
                 }
               },
               "additionalProperties": false,

--- a/schemas/ticketcreated.json
+++ b/schemas/ticketcreated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/schemas/ticketupdated.json
+++ b/schemas/ticketupdated.json
@@ -55,12 +55,8 @@
       "properties": {
         "id": {
           "type": "string",
+          "format": "uri-reference",
           "minLength": 1
-        },
-        "source": {
-          "type": "string",
-          "minLength": 1,
-          "format": "uri-reference"
         },
         "content": {
           "properties": {

--- a/spec.md
+++ b/spec.md
@@ -40,8 +40,6 @@ CDEvents is a common specification for Continuous Delivery events.
   - [REQUIRED Subject Attributes](#required-subject-attributes)
     - [id (subject)](#id-subject)
     - [content](#content)
-  - [OPTIONAL Subject Attributes](#optional-subject-attributes)
-    - [source (subject)](#source-subject)
   - [Subject example](#subject-example)
 - [CDEvents custom data](#cdevents-custom-data)
   - [OPTIONAL Custom Data attributes](#optional-custom-data-attributes)
@@ -389,18 +387,31 @@ defined in the [vocabulary](#vocabulary):
 
 #### id (subject)
 
-- Type: [`String`][typesystem]
+- Type: [`URI-Reference`][typesystem]
 - Description: Identifier for a subject.
   Subsequent events associated to the same subject MUST use the same subject
   [`id`](#id-subject).
 
 - Constraints:
   - REQUIRED
-  - MUST be a non-empty string
-  - MUST be unique within the given [`source`](#source-subject) (in the scope of
-    the producer)
+  - MUST be a non-empty URI-reference
+  - MUST be unique
+  - An absolute URI is RECOMMENDED
+  - A URI to access the subject via API is RECOMMENDED over a human-facing frontend URL
 - Examples:
-  - A [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random))
+  - An absolute URI
+    - `https://api.github.com/repos/my-org/my-repo/actions/runs/11111111111`
+  - An organization scoped PATH
+    - `/my-cluster/my-region/dev`
+    - `/my-namespace/my-deployment/my-container`
+    - `/teamX/knative-1`
+  - A [Uniform Resource Name (URN)](https://en.wikipedia.org/wiki/Uniform_Resource_Name)
+    - `urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66`
+  - A [UUID version 4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) or version 7
+  - A [Content Identifiers (CIDs) | IPFS Docs](https://docs.ipfs.tech/concepts/content-addressing/#what-is-a-cid)
+
+> [!NOTE]
+> Migration from spec 0.5 and below by merging the previous `subject.source` into `subject.id`: `subject.id = "${subject.source}/${subject.id}"`
 
 #### content
 
@@ -426,20 +437,6 @@ defined in the [vocabulary](#vocabulary):
         }
     ```
 
-### OPTIONAL Subject Attributes
-
-#### source (subject)
-
-- Type: [`URI-Reference`][typesystem]
-- Description: defines the context in which the subject originated. In most
-  cases the [`source`](#source-subject) of the subject matches the
-  [`source`](#source-context) of the event. This field should be used only in
-  cases where the [`source`](#source-subject) of the *subject* is different from
-  the [`source`](#source-context) of the event.
-
-  The format and semantic of the *subject* [`source`](#source-subject) are the
-  same of those of the *context* [`source`](#source-context).
-
 ### Subject example
 
 The following example shows `context` and `subject` together, rendered as JSON.
@@ -454,13 +451,12 @@ The following example shows `context` and `subject` together, rendered as JSON.
       "timestamp" : "2018-04-05T17:31:00Z"
    },
    "subject" : {
-      "id": "my-taskrun-123",
+      "id": "https://my-server/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123",
       "content": {
          "task": "my-task",
-         "uri": "/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123",
+         "uri": "https://my-server/apis/tekton.dev/v1beta1/namespaces/default/taskruns/my-taskrun-123",
          "pipelineRun": {
-            "id": "my-distributed-pipelinerun",
-            "source": "/tenant1/tekton/"
+            "id": "https://my-server/tenant1/tekton/my-distributed-pipelinerun",
          }
       }
    }


### PR DESCRIPTION
# Changes

Merge `subject.source` into `subject.id`:

- `subject.id` definition change (becomes an URI-reference, an global)
- remove `subject.source` and `content.{service,repository,pipelineRun,environment}.source`

see: https://github.com/cdevents/spec/issues/252 for initial proposal / discussion

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [ ] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
