### PR TITLE
fix(task): task run finished not consistent

### DIFF
--- a/schemas/taskrunfinished.json
+++ b/schemas/taskrunfinished.json
@@ -90,7 +90,8 @@
               ]
             },
             "outcome": {
-              "type": "string"
+              "type": "string",
+              "enum": ["success", "failure", "cancel", "error"]
             },
             "errors": {
               "type": "string"


### PR DESCRIPTION
This commit task run to conform to other outcome values being enums with values: "success", "failure", "error", and "cancel"