### PR TITLE
update(schemas): relax environment id requirement in service upgraded

### DIFF
--- a/schemas/servicedeployed.json
+++ b/schemas/servicedeployed.json
@@ -70,7 +70,16 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "url": {
                   "type": "string",
                   "minLength": 1,
                   "format": "uri-reference"
@@ -78,8 +87,9 @@
               },
               "additionalProperties": false,
               "type": "object",
-              "required": [
-                "id"
+              "anyOf": [
+                {"required": ["id"]},
+                {"required": ["name"]}
               ]
             },
             "artifactId": {

--- a/schemas/servicepublished.json
+++ b/schemas/servicepublished.json
@@ -70,7 +70,16 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "url": {
                   "type": "string",
                   "minLength": 1,
                   "format": "uri-reference"
@@ -78,8 +87,9 @@
               },
               "additionalProperties": false,
               "type": "object",
-              "required": [
-                "id"
+              "anyOf": [
+                {"required": ["id"]},
+                {"required": ["name"]}
               ]
             }
           },

--- a/schemas/serviceremoved.json
+++ b/schemas/serviceremoved.json
@@ -70,7 +70,16 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "url": {
                   "type": "string",
                   "minLength": 1,
                   "format": "uri-reference"
@@ -78,8 +87,9 @@
               },
               "additionalProperties": false,
               "type": "object",
-              "required": [
-                "id"
+              "anyOf": [
+                {"required": ["id"]},
+                {"required": ["name"]}
               ]
             }
           },

--- a/schemas/servicerolledback.json
+++ b/schemas/servicerolledback.json
@@ -70,7 +70,16 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "url": {
                   "type": "string",
                   "minLength": 1,
                   "format": "uri-reference"
@@ -78,8 +87,9 @@
               },
               "additionalProperties": false,
               "type": "object",
-              "required": [
-                "id"
+              "anyOf": [
+                {"required": ["id"]},
+                {"required": ["name"]}
               ]
             },
             "artifactId": {

--- a/schemas/serviceupgraded.json
+++ b/schemas/serviceupgraded.json
@@ -70,7 +70,16 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "url": {
                   "type": "string",
                   "minLength": 1,
                   "format": "uri-reference"
@@ -78,8 +87,9 @@
               },
               "additionalProperties": false,
               "type": "object",
-              "required": [
-                "id"
+              "anyOf": [
+                {"required": ["id"]},
+                {"required": ["name"]}
               ]
             },
             "artifactId": {


### PR DESCRIPTION
 ## Problem

The `environment` object in `serviceUpgraded` (and related service events) currently requires an `id` field. This creates a real-world problem for CD tools that have no concept of a named environment, but they are forced to populate `id` with a meaningless placeholder like `"n/a"`.

### Environment vs. Cluster conflation

Many CD tools (e.g. Spinnaker) operate at the cluster or namespace level, not the environment level. In these systems, a deployment target is a:

**cluster** — a concrete infrastructure resource — not an abstract **environment** like "production" or "staging". These concepts are often conflated:

   - A team may deploy the same service to `us-east-1-prod` and `eu-west-1-prod`, both of which are "production" environments, but represented as
   distinct clusters with no shared environment identifier.
   - Other tools model environment purely by name convention (`prod`, `nonprod`) with no stable ID to reference.

Requiring `id` forces these tools to either fabricate an identifier or skip the field entirely by violating the schema, neither of which is useful for consumers of the event. We need to be VERY clear on what is an environment and what is a cluster or target. Blending environment to mean cluster is ambiguous. This is out of scope for this PR, but needs to be addressed in the future, see https://github.com/cdevents/spec/issues/310

## Changes

   - Adds a `name` field to the `environment` object with `x-suggested-values: [prod, nonprod, unknown]` to provide loose governance without
   restricting the field to an enum.
   - Relaxes the `required: [id]` constraint to `anyOf: [{required: [id]}, {required: [name]}]`, so producers must supply at least one of `id` or
   `name` but not necessarily both.

This allows tools like Spinnaker to emit a meaningful `name` (e.g. `"prod"`) without needing a stable environment `id`, while tools that do have environment IDs continue to work as before.