### PR TITLE
feat(deployment): add deployment subject and queued/started/finished events

### DIFF
--- a/conformance/deployment_finished.json
+++ b/conformance/deployment_finished.json
@@ -1,0 +1,22 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.deployment.finished.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "environment": {
+        "id": "test123"
+      },
+      "outcome": "success"
+    }
+  }
+}

--- a/conformance/deployment_queued.json
+++ b/conformance/deployment_queued.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.deployment.queued.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "environment": {
+        "id": "test123"
+      }
+    }
+  }
+}

--- a/conformance/deployment_started.json
+++ b/conformance/deployment_started.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.deployment.started.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "environment": {
+        "id": "test123"
+      }
+    }
+  }
+}

--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -14,12 +14,13 @@ Continuous Deployment (CD) events are related to continuous deployment pipelines
 
 ## Subjects
 
-This specification defines two subjects in this stage: `environment` and `service`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`.
+This specification defines three subjects in this stage: `environment`, `service`, and `deployment`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`. A `deployment` is the act of applying a version of a release unit to an environment.
 
 | Subject | Description | Predicates |
 |---------|-------------|------------|
 | [`environment`](#environment) | An environment where to run services | [`created`](#environment-created), [`modified`](#environment-modified), [`deleted`](#environment-deleted)|
 | [`service`](#service) | A service | [`deployed`](#service-deployed), [`upgraded`](#service-upgraded), [`rolledback`](#service-rolledback), [`removed`](#service-removed), [`published`](#service-published)|
+| [`deployment`](#deployment) | The act of deploying a release unit to an environment | [`queued`](#deployment-queued), [`started`](#deployment-started), [`finished`](#deployment-finished)|
 
 ### `environment`
 
@@ -42,6 +43,17 @@ A `service` can represent for example a binary that is running, a daemon, an app
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
+
+### `deployment`
+
+A `deployment` is the act of applying a version of a release unit to an environment. It may be carried out by an automated CD pipeline or as a single manual action, such as a one-off `kubectl apply`; a `deployment` does not require an orchestrator or pipeline to exist. A `deployment` is that act and its outcome only, not the pipeline or tool that performed it (see [`pipelineRun`](core.md#pipelinerun)), and not the resulting state of the running service, which `service` describes separately. Where a producer's pipeline execution is itself the natural deployment boundary, its `id` MAY be reused as the `deployment` subject's `id`.
+
+| Field | Type | Description | Examples |
+|-------|------|-------------|----------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `/cd/deploy-controller` |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` |
 
 ## Events
 
@@ -147,6 +159,52 @@ This event represents the removal of a previously deployed service instance and 
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
+
+### [`deployment queued`](conformance/deployment_queued.json)
+
+This event represents a deployment that has been accepted and is waiting to begin.
+
+- Event Type: __`dev.cdevents.deployment.queued.0.1.0`__
+- Predicate: queued
+- Subject: [`deployment`](#deployment)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
+
+### [`deployment started`](conformance/deployment_started.json)
+
+This event represents a deployment controller that has begun orchestrating a rollout.
+
+- Event Type: __`dev.cdevents.deployment.started.0.1.0`__
+- Predicate: started
+- Subject: [`deployment`](#deployment)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
+
+### [`deployment finished`](conformance/deployment_finished.json)
+
+This event represents a deployment that has completed. `deployment.finished` is the orchestration-side completion fact for a deployment, analogous to `build finished` on the CI side, and is kept separate from the entity-side fact carried by `service.deployed`.
+
+- Event Type: __`dev.cdevents.deployment.finished.0.1.0`__
+- Predicate: finished
+- Subject: [`deployment`](#deployment)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
+| outcome | `String (enum)` | Outcome of the finished deployment | `success`, `failure`, `cancel`, `error` | ✅ |
 
 ### [`service published`](conformance/service_published.json)
 

--- a/schemas/_defs/deployment.json
+++ b/schemas/_defs/deployment.json
@@ -1,0 +1,19 @@
+{
+  "$id": "cdevents/_defs/deployment",
+  "term": "Deployment",
+  "definition": "A Deployment is the act of applying a version of a release unit to an environment. It may be carried out by an automated CD pipeline or as a single manual action, such as a one-off `kubectl apply`; a Deployment does not require an orchestrator or pipeline to exist. A Deployment is that act and its outcome only, not the pipeline or tool that performed it, and not the resulting state of the running service, which the `service` subject describes separately.",
+  "notes": [
+    "A Deployment is not the pipeline or tooling that executed it",
+    "A Deployment does not require an orchestrator or CD pipeline to exist; a single manual action, such as a one-off `kubectl apply`, is still a deployment",
+    "deployment separates the act of deploying (this subject) from the entity fact of a running service (`service`), mirroring the build/artifact split in CI"
+  ],
+  "examples": [
+    "Deploying myapp v1.2.3 to the production environment",
+    "A Spinnaker pipeline execution that rolls out a service to a Kubernetes cluster",
+    "A developer manually running `kubectl apply -f deploy.yaml` and reporting the outcome, with no CD pipeline involved"
+  ],
+  "counterExamples": [
+    "The pipeline that performed the deployment",
+    "The resulting running state of the service (that is `service`)"
+  ]
+}

--- a/schemas/_defs/finished.json
+++ b/schemas/_defs/finished.json
@@ -1,0 +1,20 @@
+{
+  "$id": "cdevents/_defs/finished",
+  "term": "Finished",
+  "definition": "Indicates that execution of an entity has ended, regardless of outcome. The outcome field on the event conveys whether execution succeeded or failed.",
+  "notes": [
+    "A finished event does not imply successful execution.",
+    "The outcome field must be inspected to determine success or failure.",
+    "A finished event is terminal — no further lifecycle events follow for this entity."
+  ],
+  "examples": [
+    "A deployment completing across all target rollouts",
+    "A target rollout completing at its destination",
+    "A pipeline run terminating with success or failure"
+  ],
+  "counterExamples": [
+    "Intermediate execution states",
+    "Progress or partial completion signals",
+    "Cancellation requests (the finished event is emitted after cancellation is complete)"
+  ]
+}

--- a/schemas/_defs/queued.json
+++ b/schemas/_defs/queued.json
@@ -1,0 +1,18 @@
+{
+  "$id": "cdevents/_defs/queued",
+  "term": "Queued",
+  "definition": "Indicates that an entity has been accepted and is waiting to begin execution.",
+  "notes": [
+    "A queued event does not imply that execution has started.",
+    "The associated entity may be held by scheduling, resource availability, or dependencies."
+  ],
+  "examples": [
+    "A deployment accepted by a deploy controller and waiting for resources",
+    "A target rollout scheduled but not yet executing",
+    "A pipeline run waiting in a queue before a worker picks it up"
+  ],
+  "counterExamples": [
+    "Active execution of the entity",
+    "Completion or failure of the entity"
+  ]
+}

--- a/schemas/deploymentfinished.json
+++ b/schemas/deploymentfinished.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/deployment-finished-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/deployment",
+    "predicate": "cdevents/_defs/finished"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.deployment.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.deployment.finished.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "outcome": {
+              "type": "string",
+              "enum": [
+                "success",
+                "failure",
+                "cancel",
+                "error"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "artifactId",
+            "environment",
+            "outcome"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/deploymentqueued.json
+++ b/schemas/deploymentqueued.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/deployment-queued-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/deployment",
+    "predicate": "cdevents/_defs/queued"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.deployment.queued.0.1.0"
+          ],
+          "default": "dev.cdevents.deployment.queued.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "artifactId",
+            "environment"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/deploymentstarted.json
+++ b/schemas/deploymentstarted.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/deployment-started-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/deployment",
+    "predicate": "cdevents/_defs/started"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.deployment.started.0.1.0"
+          ],
+          "default": "dev.cdevents.deployment.started.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "artifactId",
+            "environment"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}


### PR DESCRIPTION
## Problem

`service.deployed`/`service.upgraded` conflate two different kinds of fact into one event. Every other subject pair in the spec separates *orchestration* (the act of doing something) from *entity* (the resulting state) — `build` is the orchestration event, `artifact` is the entity fact it produces. `service.deployed`/`upgraded` are the one place that doesn't hold: a single event tries to say both "a rollout happened" and "this service instance is now running v2," with no way to talk about the rollout on its own. That's also why `service` has no `queued`/`started` predicates — queuing and starting are true of a deployment, not of a service, so producers who need lifecycle visibility into an in-progress rollout have no canonical event to emit and end up inventing their own conventions.

This also means there's no way to represent a single deployment fanning out to multiple simultaneous destinations with one aggregate outcome — e.g. rolling a release out to 3 regions, or to a canary slot plus the main fleet, within the same environment. Today you'd emit N separate `service.deployed` events and the consumer has to infer, out of band, which ones belong to the same deployment attempt and what the combined success/failure state is.

Finally, `environment` has no inbound link to what's running in it. `environment.created`/`modified`/`deleted` describe the platform alone; the only way to find out what's deployed into an environment today is to scan `service` events and filter on `content.environment.id`, a reference that points from the entity down to the environment — backwards from every other "what happened in this environment" query you'd want to run.

## Solution

Introduces `deployment` (the aggregate act of applying a release to one or more target rollouts, one per environment) and `targetRollout` (a specific destination within that environment, e.g. a region or canary slot) as the orchestration-side subjects `service` was missing, each with `queued`/`started`/`finished` lifecycle events. `targetRollout.finished` carries `failureType` for per-destination failure detail; `deployment.finished` is all-or-nothing across all of its target rollouts.

`targetRollout` also gives `environment` a first-class inbound link: querying "what was rolled out to this environment" becomes direct instead of an inference over `service` events.

`service.deployed`/`service.upgraded` are unchanged in behavior and retained for backwards compatibility as the entity-side fact, now deprecated in favor of `deployment.finished`/`targetRollout.finished` for the orchestration-side fact.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [ ] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [ ] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [ ] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
