### PR TITLE
feat(cd): add migration subject and events

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -60,6 +60,7 @@ schemas
 schemauri
 specversion
 src
+stateful
 subjectid
 taskrun
 testcase

--- a/conformance/migration_finished.json
+++ b/conformance/migration_finished.json
@@ -1,0 +1,63 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/gitops/k8s/migrations",
+    "type": "dev.cdevents.migration.finished.0.1.0-draft",
+    "timestamp": "2026-07-27T17:31:00Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "V12__add_order_status",
+    "source": "/gitops/k8s/migrations",
+    "content": {
+      "target": {
+        "id": "orders-db",
+        "source": "/prod/postgres/orders",
+        "type": "database"
+      },
+      "fromVersion": "11",
+      "toVersion": "12",
+      "reversible": false,
+      "change": {
+        "id": "a8f3c21",
+        "source": "/scm/github/orders-svc"
+      },
+      "outcome": "success"
+    }
+  }
+}

--- a/conformance/migration_queued.json
+++ b/conformance/migration_queued.json
@@ -1,0 +1,62 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/gitops/k8s/migrations",
+    "type": "dev.cdevents.migration.queued.0.1.0-draft",
+    "timestamp": "2026-07-27T17:31:00Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "V12__add_order_status",
+    "source": "/gitops/k8s/migrations",
+    "content": {
+      "target": {
+        "id": "orders-db",
+        "source": "/prod/postgres/orders",
+        "type": "database"
+      },
+      "fromVersion": "11",
+      "toVersion": "12",
+      "reversible": false,
+      "change": {
+        "id": "a8f3c21",
+        "source": "/scm/github/orders-svc"
+      }
+    }
+  }
+}

--- a/conformance/migration_started.json
+++ b/conformance/migration_started.json
@@ -1,0 +1,62 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/gitops/k8s/migrations",
+    "type": "dev.cdevents.migration.started.0.1.0-draft",
+    "timestamp": "2026-07-27T17:31:00Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "V12__add_order_status",
+    "source": "/gitops/k8s/migrations",
+    "content": {
+      "target": {
+        "id": "orders-db",
+        "source": "/prod/postgres/orders",
+        "type": "database"
+      },
+      "fromVersion": "11",
+      "toVersion": "12",
+      "reversible": false,
+      "change": {
+        "id": "a8f3c21",
+        "source": "/scm/github/orders-svc"
+      }
+    }
+  }
+}

--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -16,10 +16,13 @@ Continuous Deployment (CD) events are related to continuous deployment pipelines
 
 This specification defines two subjects in this stage: `environment` and `service`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`.
 
+Deployments also change resources that hold state. A [`migration`](#migration) is a versioned change applied to a stateful resource, such as a database schema, the data it holds, or a configuration store.
+
 | Subject | Description | Predicates |
 |---------|-------------|------------|
 | [`environment`](#environment) | An environment where to run services | [`created`](#environment-created), [`modified`](#environment-modified), [`deleted`](#environment-deleted)|
 | [`service`](#service) | A service | [`deployed`](#service-deployed), [`upgraded`](#service-upgraded), [`rolledback`](#service-rolledback), [`removed`](#service-removed), [`published`](#service-published)|
+| [`migration`](#migration) | A versioned change applied to a stateful resource | [`queued`](#migration-queued), [`started`](#migration-started), [`finished`](#migration-finished)|
 
 ### `environment`
 
@@ -42,6 +45,30 @@ A `service` can represent for example a binary that is running, a daemon, an app
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
+
+### `migration`
+
+A [`migration`](#migration) is a versioned change applied to a stateful resource: a database schema, the data it holds, or a configuration store. It runs to completion, and `toVersion` identifies the version it applied.
+
+What distinguishes a `migration` from other versioned work is that undoing it may not be possible. For a `service`, recovery is a deployment of an earlier artifact — another forward action, always available. For stored state it may not be: dropped columns and deleted rows do not come back by running the same step again. `reversible` declares, per occurrence, whether a clean reversal of this particular change exists.
+
+When `reversible` is absent, reversibility is undeclared. A consumer MUST NOT read an absent `reversible` as `true`. Producers able to determine it, such as tools that keep an explicit undo script alongside each change, SHOULD declare it.
+
+A reversal, where one is possible, is itself a `migration` — a later occurrence carrying the earlier version in `toVersion`. There is therefore no `reverted` predicate. Applying a change against a temporary copy to check it first is a [`testCaseRun`](testing-events.md#testcaserun), not a `migration`.
+
+A `migration` that finds nothing to apply emits nothing.
+
+| Field | Type | Description | Examples |
+|-------|------|-------------|----------|
+| id    | `String` | See [id](spec.md#id-subject)| `V12__add_order_status` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `/gitops/k8s/migrations` |
+| target | `Object` | The stateful resource that was changed. `type` names its kind. | `{"id": "orders-db", "source": "/prod/postgres/orders", "type": "database"}` |
+| fromVersion | `String` | The version the target held beforehand, when the producer knows it | `11` |
+| toVersion | `String` | The version this migration applied | `12` |
+| reversible | `Boolean` | Whether a clean reversal of this change exists | `false` |
+| change | `Object` ([`change`](source-code-version-control.md#change)) | The change that authored this migration, when one exists | `{"id": "a8f3c21", "source": "/scm/github/orders-svc"}` |
+| outcome | `String (enum)` | outcome of a finished `migration` | `success`, `failure`, `cancel`, or `error` |
+| errors | `String` | In case of error, canceled, or failed migration, provides details about the failure | `Constraint violation on orders.status` |
 
 ## Events
 
@@ -161,3 +188,61 @@ This event represents an existing instance of a service that has an accessible U
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
+
+### [`migration queued`](conformance/migration_queued.json)
+
+A migration has been accepted for execution. No changes have been applied to the target yet.
+
+- Event Type: __`dev.cdevents.migration.queued.0.1.0-draft`__
+- Predicate: queued
+- Subject: [`migration`](#migration)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `V12__add_order_status` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The stateful resource to be changed | `{"id": "orders-db", "source": "/prod/postgres/orders", "type": "database"}` | ✅ |
+| fromVersion | `String` | The version the target holds beforehand, when known | `11` | |
+| toVersion | `String` | The version this migration will apply | `12` | ✅ |
+| reversible | `Boolean` | Whether a clean reversal of this change exists | `false` | |
+| change | `Object` ([`change`](source-code-version-control.md#change)) | The change that authored this migration | `{"id": "a8f3c21", "source": "/scm/github/orders-svc"}` | |
+
+### [`migration started`](conformance/migration_started.json)
+
+A migration has begun applying changes to the target.
+
+- Event Type: __`dev.cdevents.migration.started.0.1.0-draft`__
+- Predicate: started
+- Subject: [`migration`](#migration)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `V12__add_order_status` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The stateful resource being changed | `{"id": "orders-db", "source": "/prod/postgres/orders", "type": "database"}` | ✅ |
+| fromVersion | `String` | The version the target held beforehand, when known | `11` | |
+| toVersion | `String` | The version this migration is applying | `12` | ✅ |
+| reversible | `Boolean` | Whether a clean reversal of this change exists | `false` | |
+| change | `Object` ([`change`](source-code-version-control.md#change)) | The change that authored this migration | `{"id": "a8f3c21", "source": "/scm/github/orders-svc"}` | |
+
+### [`migration finished`](conformance/migration_finished.json)
+
+A migration has terminated, successfully or not.
+
+When `reversible` is `false` and `outcome` is `success`, the change is a commitment that cannot be cleanly undone; recovery must be a new forward migration.
+
+- Event Type: __`dev.cdevents.migration.finished.0.1.0-draft`__
+- Predicate: finished
+- Subject: [`migration`](#migration)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `V12__add_order_status` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The stateful resource that was changed | `{"id": "orders-db", "source": "/prod/postgres/orders", "type": "database"}` | ✅ |
+| fromVersion | `String` | The version the target held beforehand, when known | `11` | |
+| toVersion | `String` | The version this migration applied | `12` | ✅ |
+| reversible | `Boolean` | Whether a clean reversal of this change exists | `false` | |
+| change | `Object` ([`change`](source-code-version-control.md#change)) | The change that authored this migration | `{"id": "a8f3c21", "source": "/scm/github/orders-svc"}` | |
+| outcome | `String (enum)` | outcome of a finished `migration` | `success`, `failure`, `cancel`, or `error` | `success`, `failure`, `cancel`, `error` |
+| errors | `String` | In case of error, canceled, or failed migration, provides details about the failure | `Constraint violation on orders.status` | |

--- a/schemas/migrationfinished.json
+++ b/schemas/migrationfinished.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/migration-finished-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.migration.finished.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.migration.finished.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "fromVersion": {
+              "type": "string"
+            },
+            "toVersion": {
+              "type": "string"
+            },
+            "reversible": {
+              "type": "boolean"
+            },
+            "change": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "outcome": {
+              "type": "string",
+              "enum": [
+                "success",
+                "failure",
+                "cancel",
+                "error"
+              ]
+            },
+            "errors": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "toVersion",
+            "outcome"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/migrationqueued.json
+++ b/schemas/migrationqueued.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/migration-queued-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.migration.queued.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.migration.queued.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "fromVersion": {
+              "type": "string"
+            },
+            "toVersion": {
+              "type": "string"
+            },
+            "reversible": {
+              "type": "boolean"
+            },
+            "change": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "toVersion"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/migrationstarted.json
+++ b/schemas/migrationstarted.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/migration-started-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.migration.started.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.migration.started.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "fromVersion": {
+              "type": "string"
+            },
+            "toVersion": {
+              "type": "string"
+            },
+            "reversible": {
+              "type": "boolean"
+            },
+            "change": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "toVersion"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}


### PR DESCRIPTION
# Changes

Adds a `migration` subject to the Continuous Deployment vocabulary, with `queued`, `started` and `finished` predicates.

A `migration` is a run-to-completion, versioned change applied to a **stateful** resource — a database schema, the data it holds, or a configuration store.

## Why a new subject

This came from a DataOps request: a GitOps-governed database schema change, where the operator needed to know from the event stream whether what had just landed could be undone.

Nothing in the current vocabulary answers that. For stateless work, recovery is a redeploy of a prior revision — another forward action that needs no declaration, because the option always exists. For persistent state it may not: dropped columns and deleted rows do not come back by re-running anything. A consumer that automates recovery, or that decides whether to page a human, needs to know which case it is at the moment the event arrives.

That property is routing-relevant rather than payload, which is the bar for a distinct subject. It cannot be inferred from a versioned run in general, and it cannot be inferred from the tool that emitted it.

## `reversible` is the field the subject exists to carry

It is tri-state by design:

- `false` — no clean reversal exists; recovery must be a new forward migration.
- `true` — a clean reversal exists.
- **absent** — recoverability is *undeclared*. Consumers MUST NOT infer that an omitted `reversible` means `true`.

Producers that can determine reversibility — tools that keep an explicit undo or rollback script alongside each change — SHOULD declare it. The schema does not make it required, because a producer that cannot determine it should not be forced to guess.

## Scope

`migration` is scoped to stateful, persistent resources: the class where recoverability is genuinely in question. The broader alternative — any versioned forward step — was considered and not taken, because where recoverability is not in question there is nothing for a consumer to route on, and the subject would then overlap work `taskRun` already describes.

## Design decisions

**`target` carries a `type` alongside `id` and `source`,** so consumers can route on the kind of resource that was changed, and so target references are shaped consistently across subjects. `type` is a free string — `database`, `configStore` — rather than a closed enum, so the subject is not coupled to a fixed list of storage kinds.

**`toVersion` is required and `fromVersion` is optional.** It was put to us that migration tools often do not expose "from" and "to" in their output, and that an adapter would be unable to fill them. The asymmetry is deliberate and answers that: a producer always knows the version it applied — that is the artifact it carries, and in most tools it is the subject id itself (`V12__add_order_status`). What a producer frequently does *not* know is the version it overwrote, which requires querying prior state. Requiring `toVersion` asks a producer only for what it has in hand; requiring `fromVersion` would turn the event into a pre-processing step.

**There is no `reverted` predicate.** A reversal, where possible, is itself a forward `migration` — a later occurrence with `toVersion` set to the earlier version. When `reversible` is `false`, `migration.finished` with `outcome: success` is a non-reversible commitment, so verification belongs before it fires. Applying a change against a temporary database in CI is a `testCaseRun`, not a `migration`.

**A migration that finds nothing to apply emits nothing.** No migration occurred, so there is no occurrence to report. This keeps the subject an occurrence model rather than a polling report.

**No field describes a partially applied migration.** Why a migration stopped where it did is answerable only from the surrounding workflow — the emitting step does not observe its siblings, and cannot report on them. Consumers needing it should read the enclosing workflow's completion.

**`target` is singular, not an array.** A single logical change spanning several stores was considered. One event covering N targets cannot report an outcome for each, and near-atomicity across stores is a claim the vocabulary cannot verify. These remain N occurrences; whether they form one logical unit is a property of the workflow that produced them.

**No attempt identifier.** A retry is a new occurrence with its own identity, and numbering attempts asks a producer to carry correlation state it would have to compute. This is also not specific to `migration`; if attempt identity is wanted, it belongs in the context for every subject.

**`change` is reused unchanged** from the existing [`change`](https://github.com/cdevents/spec/blob/main/source-code-version-control.md#change) subject. No new common objects are introduced.

## Out of scope

- **The authorization decision to run a migration.** `approval` already covers accountable authorization decisions that gate execution. A migration gated by an approval is two occurrences.
- **Enforcement.** Whether a migration is permitted to proceed is control-plane behavior. These events are the record of what happened.

## Notes on this change

Event versions start at `0.1.0-draft`.

`schemas/_defs/` entries and `x-cdevents-semantics` are not included here. The predicate definitions this subject would need (`queued`, `finished`) are already being added by #319, and further subjects we are proposing would need `created` and `modified`; adding them here would collide. We will follow up with them once #319 lands.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved — *no new concept is introduced; this applies existing vocabulary patterns*
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning) — *new events start at `0.1.0-draft`; the spec version is unchanged*
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
