### PR TITLE
feat(core): add scheduledExecution subject and events

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -34,6 +34,9 @@ dataschema
 deterministically
 emmitted
 english
+enqueue
+enqueued
+enqueueing
 eventdata
 fas
 href
@@ -55,6 +58,7 @@ pre
 rolledback
 runtime
 sbom
+scheduledexecution
 schemaUri
 schemas
 schemauri

--- a/conformance/scheduledexecution_canceled.json
+++ b/conformance/scheduledexecution_canceled.json
@@ -1,0 +1,65 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/scheduler/prod",
+    "type": "dev.cdevents.scheduledexecution.canceled.0.1.0-draft",
+    "timestamp": "2026-08-12T02:00:03Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "sched-deploy-orders-9281",
+    "source": "/scheduler/prod",
+    "content": {
+      "target": {
+        "id": "orders-svc",
+        "source": "/prod/deploys",
+        "type": "deployment"
+      },
+      "scheduledTime": "2026-08-12T02:00:00Z",
+      "author": {
+        "id": "alice",
+        "source": "/scheduler/prod"
+      },
+      "changeWindow": {
+        "id": "win-maint-0812",
+        "source": "/scheduler/prod"
+      },
+      "reason": "Superseded by an out-of-band release"
+    }
+  }
+}

--- a/conformance/scheduledexecution_created.json
+++ b/conformance/scheduledexecution_created.json
@@ -1,0 +1,64 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/scheduler/prod",
+    "type": "dev.cdevents.scheduledexecution.created.0.1.0-draft",
+    "timestamp": "2026-08-12T02:00:03Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "sched-deploy-orders-9281",
+    "source": "/scheduler/prod",
+    "content": {
+      "target": {
+        "id": "orders-svc",
+        "source": "/prod/deploys",
+        "type": "deployment"
+      },
+      "scheduledTime": "2026-08-12T02:00:00Z",
+      "author": {
+        "id": "alice",
+        "source": "/scheduler/prod"
+      },
+      "changeWindow": {
+        "id": "win-maint-0812",
+        "source": "/scheduler/prod"
+      }
+    }
+  }
+}

--- a/conformance/scheduledexecution_missed.json
+++ b/conformance/scheduledexecution_missed.json
@@ -1,0 +1,61 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/scheduler/prod",
+    "type": "dev.cdevents.scheduledexecution.missed.0.1.0-draft",
+    "timestamp": "2026-08-12T02:00:03Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "sched-deploy-orders-9281",
+    "source": "/scheduler/prod",
+    "content": {
+      "target": {
+        "id": "orders-svc",
+        "source": "/prod/deploys",
+        "type": "deployment"
+      },
+      "scheduledTime": "2026-08-12T02:00:00Z",
+      "changeWindow": {
+        "id": "win-maint-0812",
+        "source": "/scheduler/prod"
+      },
+      "reason": "Scheduler backlog exceeded the firing window"
+    }
+  }
+}

--- a/conformance/scheduledexecution_modified.json
+++ b/conformance/scheduledexecution_modified.json
@@ -1,0 +1,64 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/scheduler/prod",
+    "type": "dev.cdevents.scheduledexecution.modified.0.1.0-draft",
+    "timestamp": "2026-08-12T02:00:03Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "sched-deploy-orders-9281",
+    "source": "/scheduler/prod",
+    "content": {
+      "target": {
+        "id": "orders-svc",
+        "source": "/prod/deploys",
+        "type": "deployment"
+      },
+      "scheduledTime": "2026-08-12T02:00:00Z",
+      "author": {
+        "id": "alice",
+        "source": "/scheduler/prod"
+      },
+      "changeWindow": {
+        "id": "win-maint-0812",
+        "source": "/scheduler/prod"
+      }
+    }
+  }
+}

--- a/conformance/scheduledexecution_triggered.json
+++ b/conformance/scheduledexecution_triggered.json
@@ -1,0 +1,67 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/scheduler/prod",
+    "type": "dev.cdevents.scheduledexecution.triggered.0.1.0-draft",
+    "timestamp": "2026-08-12T02:00:03Z",
+    "schemaUri": "https://myorg.com/schema/custom",
+    "links": [
+      {
+        "linkType": "RELATION",
+        "linkKind": "TRIGGER",
+        "target": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "PATH",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      },
+      {
+        "linkType": "END",
+        "from": {
+          "contextId": "5328c37f-bb7e-4bb7-84ea-9f5f85e4a7ce"
+        },
+        "tags": {
+          "foo1": "bar",
+          "foo2": "bar"
+        }
+      }
+    ]
+  },
+  "subject": {
+    "id": "sched-deploy-orders-9281",
+    "source": "/scheduler/prod",
+    "content": {
+      "target": {
+        "id": "orders-svc",
+        "source": "/prod/deploys",
+        "type": "deployment"
+      },
+      "scheduledTime": "2026-08-12T02:00:00Z",
+      "trigger": {
+        "type": "schedule"
+      },
+      "changeWindow": {
+        "id": "win-maint-0812",
+        "source": "/scheduler/prod"
+      },
+      "triggeredExecution": {
+        "id": "deploy-44119",
+        "source": "/prod/deploys"
+      }
+    }
+  }
+}

--- a/core.md
+++ b/core.md
@@ -18,10 +18,13 @@ Core events are at the lower level of abstraction in the dictionary: they descri
 In the context of Continuous Delivery, a *pipeline* is the definition of a set of *tasks* that needs to be performed to build, test, package, release and deploy software artifacts.
 The definition of *pipelines* and *tasks* is an authoring process, and has no event associated to it. CDEvents identifies two [*subjects*](spec.md#subject), [`pipelineRun`](#pipelinerun) and [`taskRun`](#taskrun), which are the runtime counterparts of *pipelines* and *tasks*.
 
+Executions are not always enqueued as soon as they are requested. A [`scheduledExecution`](#scheduledexecution) is the registered intent to enqueue an execution at a future time, and covers the lifecycle before enqueueing.
+
 | Subject | Description | Predicates |
 |---------|-------------|------------|
 | [`pipelineRun`](#pipelinerun) | An instance of a *pipeline* | [`queued`](#pipelinerun-queued), [`started`](#pipelinerun-started), [`finished`](#pipelinerun-finished)|
 | [`taskRun`](#taskrun) | An instance of a *task* | [`queued`](#taskrun-queued), [`started`](#taskrun-started), [`finished`](#taskrun-finished)|
+| [`scheduledExecution`](#scheduledexecution) | A registered intent to enqueue an execution at a future time | [`created`](#scheduledexecution-created), [`modified`](#scheduledexecution-modified), [`canceled`](#scheduledexecution-canceled), [`triggered`](#scheduledexecution-triggered), [`missed`](#scheduledexecution-missed)|
 
 ### `pipelineRun`
 
@@ -57,6 +60,30 @@ associated, in which case it is acceptable to generate only taskRun events.
 | outcome | `String` | outcome of a finished `taskRun` | `success`, `failure`, `cancel`, or `error` |
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` |
 | errors | `String` | In case of error, canceled, or failed pipeline , provides details about the failure | `Invalid input param 123`, `Timeout during execution`, `taskRun canceled by user`, `Unit tests failed`|
+
+### `scheduledExecution`
+
+A [`scheduledExecution`](#scheduledexecution) is a registered intent to enqueue a target execution at a future time. It is the registration, not the execution: it covers the lifecycle *before* enqueueing, during which the schedule may be amended, and then either fires, is canceled, or does not fire at all.
+
+The existing `queued` predicates represent work already accepted into an execution queue. A schedule registered today to fire next week is not visible in the event stream until it materializes as a queued execution, by which point the registration, any amendment to it, and any cancellation have left no trace. Making the schedule a subject records that history as it happens.
+
+When a `scheduledExecution` fires, it produces the target's own `queued` event. Whether the resulting execution succeeds is reported by the target's events, not by this subject.
+
+Two times are relevant and both are carried: `scheduledTime` is the time the execution was registered to fire, while [`timestamp`](spec.md#timestamp) in the context is the time the occurrence happened. On [`triggered`](#scheduledexecution-triggered), the difference between them records whether the firing was on time.
+
+The producing scheduler or controller is identified by [`source`](spec.md#source-context) in the context. `author` records the actor that the producing system attributes the action to; CDEvents records attributed identity, and proving it is the producer's responsibility.
+
+| Field | Type | Description | Examples |
+|-------|------|-------------|----------|
+| id    | `String` | See [id](spec.md#id-subject)| `sched-deploy-orders-9281` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | |
+| target | `Object` | The execution to be enqueued. `type` names what is scheduled. | `{"id": "orders-svc", "source": "/prod/deploys", "type": "deployment"}` |
+| scheduledTime | `Timestamp` | The time the execution is registered to fire | `2026-08-12T02:00:00Z` |
+| author | `Object` | The actor the producer attributes the action to | `{"id": "alice", "source": "/scheduler/prod"}` |
+| trigger | `Object` ([`trigger`](testing-events.md#trigger)) | What caused the firing | `{"type": "schedule"}`, `{"type": "manual"}` |
+| changeWindow | `Object` | A change window this execution is bound to, if any | `{"id": "win-maint-0812", "source": "/scheduler/prod"}` |
+| triggeredExecution | `Object` | The execution that was enqueued | `{"id": "deploy-44119", "source": "/prod/deploys"}` |
+| reason | `String` | Detail for a cancellation or a missed firing | `Superseded by an out-of-band release` |
 
 ## Events
 
@@ -162,3 +189,95 @@ A taskRun has finished, successfully or not.
 | url | `URI` | url to the `taskRun` | `https://dashboard.org/namespace/taskrun-1234`, `https://api.cdsystem.com/namespace/taskrun-1234` | |
 | outcome | `String (enum)` | outcome of a finished `taskRun` | `success`, `failure`, `cancel`, or `error` | `success`, `failure`, `cancel`, `error` |
 | errors | `String` | In case of error, canceled, or failed pipeline , provides details about the failure | `Invalid input param 123`, `Timeout during execution`, `taskRun canceled by user`, `Unit tests failed`| |
+
+### [`scheduledExecution Created`](conformance/scheduledexecution_created.json)
+
+A scheduled execution has been registered to fire at a future time.
+
+- Event Type: __`dev.cdevents.scheduledexecution.created.0.1.0-draft`__
+- Predicate: created
+- Subject: [`scheduledExecution`](#scheduledexecution)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `sched-deploy-orders-9281` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The execution to be enqueued | `{"id": "orders-svc", "source": "/prod/deploys", "type": "deployment"}` | ✅ |
+| scheduledTime | `Timestamp` | The time the execution is registered to fire | `2026-08-12T02:00:00Z` | ✅ |
+| author | `Object` | The actor the producer attributes the registration to | `{"id": "alice", "source": "/scheduler/prod"}` | ✅ |
+| changeWindow | `Object` | A change window this execution is bound to, if any | `{"id": "win-maint-0812", "source": "/scheduler/prod"}` | |
+
+### [`scheduledExecution Modified`](conformance/scheduledexecution_modified.json)
+
+A registered scheduled execution has been changed. The subject retains its identity across the change.
+
+- Event Type: __`dev.cdevents.scheduledexecution.modified.0.1.0-draft`__
+- Predicate: modified
+- Subject: [`scheduledExecution`](#scheduledexecution)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `sched-deploy-orders-9281` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The execution to be enqueued, as it stands after the change | `{"id": "orders-svc", "source": "/prod/deploys", "type": "deployment"}` | ✅ |
+| scheduledTime | `Timestamp` | The firing time as it stands after the change | `2026-08-12T02:00:00Z` | ✅ |
+| author | `Object` | The actor the producer attributes the change to | `{"id": "alice", "source": "/scheduler/prod"}` | ✅ |
+| changeWindow | `Object` | A change window this execution is bound to, if any | `{"id": "win-maint-0812", "source": "/scheduler/prod"}` | |
+
+### [`scheduledExecution Canceled`](conformance/scheduledexecution_canceled.json)
+
+A registered scheduled execution has been withdrawn before firing. Nothing was enqueued.
+
+- Event Type: __`dev.cdevents.scheduledexecution.canceled.0.1.0-draft`__
+- Predicate: canceled
+- Subject: [`scheduledExecution`](#scheduledexecution)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `sched-deploy-orders-9281` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The execution that will now not be enqueued | `{"id": "orders-svc", "source": "/prod/deploys", "type": "deployment"}` | ✅ |
+| scheduledTime | `Timestamp` | The time the execution had been registered to fire | `2026-08-12T02:00:00Z` | ✅ |
+| author | `Object` | The actor the producer attributes the cancellation to | `{"id": "alice", "source": "/scheduler/prod"}` | ✅ |
+| changeWindow | `Object` | A change window this execution was bound to, if any | `{"id": "win-maint-0812", "source": "/scheduler/prod"}` | |
+| reason | `String` | Detail for the cancellation | `Superseded by an out-of-band release` | |
+
+### [`scheduledExecution Triggered`](conformance/scheduledexecution_triggered.json)
+
+A scheduled execution has fired and handed off to the execution it describes. This is the point at which the target's own `queued` event is produced.
+
+Firing is caused either by elapsed time or by an actor, and `trigger.type` records which. `author` is required when `trigger.type` is `manual`, and MUST NOT be present for any other value: the absence of `author` is what tells a consumer that no actor fired the execution.
+
+- Event Type: __`dev.cdevents.scheduledexecution.triggered.0.1.0-draft`__
+- Predicate: triggered
+- Subject: [`scheduledExecution`](#scheduledexecution)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `sched-deploy-orders-9281` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The execution that was enqueued | `{"id": "orders-svc", "source": "/prod/deploys", "type": "deployment"}` | ✅ |
+| scheduledTime | `Timestamp` | The time the execution had been registered to fire | `2026-08-12T02:00:00Z` | ✅ |
+| trigger | `Object` ([`trigger`](testing-events.md#trigger)) | What caused the firing | `{"type": "schedule"}`, `{"type": "manual"}` | ✅ |
+| author | `Object` | The actor that fired the execution. MUST NOT be present unless `trigger.type` is `manual`. | `{"id": "alice", "source": "/scheduler/prod"}` | when `trigger.type` is `manual` |
+| changeWindow | `Object` | A change window this execution is bound to, if any | `{"id": "win-maint-0812", "source": "/scheduler/prod"}` | |
+| triggeredExecution | `Object` | The execution that was enqueued | `{"id": "deploy-44119", "source": "/prod/deploys"}` | |
+
+### [`scheduledExecution Missed`](conformance/scheduledexecution_missed.json)
+
+A scheduled execution did not fire. `scheduledTime` passed without the execution being enqueued.
+
+This event is emitted at the producer's discretion by a producer that was available to observe the absence; the specification defines no tolerance window. A producer that was itself unavailable at `scheduledTime` emits nothing, including no `missed` event. A schedule that never fired is distinct from an execution that fired and then failed, which is reported by the target's own events.
+
+- Event Type: __`dev.cdevents.scheduledexecution.missed.0.1.0-draft`__
+- Predicate: missed
+- Subject: [`scheduledExecution`](#scheduledexecution)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `sched-deploy-orders-9281` | ✅ |
+| source | `URI-Reference` | [source](spec.md#source) from the context | | |
+| target | `Object` | The execution that was not enqueued | `{"id": "orders-svc", "source": "/prod/deploys", "type": "deployment"}` | ✅ |
+| scheduledTime | `Timestamp` | The time the execution had been registered to fire | `2026-08-12T02:00:00Z` | ✅ |
+| changeWindow | `Object` | A change window this execution was bound to, if any | `{"id": "win-maint-0812", "source": "/scheduler/prod"}` | |
+| reason | `String` | Detail for the missed firing | `Scheduler backlog exceeded the firing window` | |

--- a/schemas/scheduledexecutioncanceled.json
+++ b/schemas/scheduledexecutioncanceled.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/scheduledexecution-canceled-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.scheduledexecution.canceled.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.scheduledexecution.canceled.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "scheduledTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "author": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "changeWindow": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "reason": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "scheduledTime",
+            "author"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/scheduledexecutioncreated.json
+++ b/schemas/scheduledexecutioncreated.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/scheduledexecution-created-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.scheduledexecution.created.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.scheduledexecution.created.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "scheduledTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "author": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "changeWindow": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "scheduledTime",
+            "author"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/scheduledexecutionmissed.json
+++ b/schemas/scheduledexecutionmissed.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/scheduledexecution-missed-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.scheduledexecution.missed.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.scheduledexecution.missed.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "scheduledTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "changeWindow": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "reason": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "scheduledTime"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/scheduledexecutionmodified.json
+++ b/schemas/scheduledexecutionmodified.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/scheduledexecution-modified-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.scheduledexecution.modified.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.scheduledexecution.modified.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "scheduledTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "author": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "changeWindow": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "scheduledTime",
+            "author"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/scheduledexecutiontriggered.json
+++ b/schemas/scheduledexecutiontriggered.json
@@ -1,0 +1,247 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/scheduledexecution-triggered-event",
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.scheduledexecution.triggered.0.1.0-draft"
+          ],
+          "default": "dev.cdevents.scheduledexecution.triggered.0.1.0-draft"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "target": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                },
+                "type": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "scheduledTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "author": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "trigger": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "manual",
+                    "pipeline",
+                    "event",
+                    "schedule",
+                    "other"
+                  ]
+                },
+                "uri": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "changeWindow": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "triggeredExecution": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "target",
+            "scheduledTime",
+            "trigger"
+          ],
+          "allOf": [
+            {
+              "properties": {
+                "trigger": {
+                  "required": [
+                    "type"
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "trigger"
+                ],
+                "properties": {
+                  "trigger": {
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "type": {
+                        "const": "manual"
+                      }
+                    }
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "author"
+                ]
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "author"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}


### PR DESCRIPTION
# Changes

Adds a `scheduledExecution` subject to the Core vocabulary, with `created`, `modified`, `canceled`, `triggered` and `missed` predicates.

A `scheduledExecution` is a registered intent to enqueue a target execution — a build, a deployment, a change window opening — at a future time. It covers the lifecycle *before* enqueueing: the schedule is registered, possibly changed, and then either fires, is canceled, or does not fire at all.

## Why a new subject

This came from an operator running scheduled deployments who needed the event stream to answer six questions: who scheduled a build or deployment, whether the schedule was subsequently changed, who changed it, whether it was canceled, who canceled it, and whether it actually fired and when.

The existing `queued` predicates cannot answer any of them. `build.queued` and the `service` deployment events represent work already accepted into an execution queue — the earliest moment the vocabulary can currently express. A schedule registered today to fire next Tuesday is invisible until it materializes as a queued execution, and by then the registration, every amendment to it, and any cancellation have left no trace.

Making the schedule itself a subject puts that history in the stream. `triggered` is the hand-off: the occurrence that subsequently produces the existing `queued` event for the target.

## `author` on `triggered`

`author` is required when `trigger.type` is `manual`, and MUST NOT be present for any other value. The schema encodes both directions, and requires `trigger.type` so neither branch can be evaded.

The biconditional is the point. Because the absence of `author` is what tells a consumer that no actor fired the execution, a time-fired event must not carry one — attaching the schedule's creator there would misreport a weeks-old registration as a person running something today. A pipeline or an event is likewise not a person, so those values carry no `author` either.

**Manual firing is ordinary, not an exception.** A scheduler's "Run Now" is the normal way an author tests a schedule before trusting it to fire unattended. It is therefore an attribute of `triggered` rather than a separate predicate, which would rest on the premise that "Run Now" is unusual. Audit interest in off-schedule firing of a sensitive target is a consumer policy — filter on `trigger.type` and target — not a vocabulary distinction.

## `missed`

`missed` is a live producer reporting that a scheduled execution did not fire. It distinguishes a schedule that never fired from an execution that fired and then failed; the latter is reported by the target's own events.

Emission is at the producer's discretion and the vocabulary sets no tolerance window. A normative threshold was considered and not taken: arrival time cannot be predicted accurately in a distributed system, so any threshold would encode a guarantee the transport cannot make. Producers know their own scheduling semantics, and consumers should read `scheduledTime` against the event's own timestamp rather than rely on a standard grace period.

A producer that was itself unavailable at `scheduledTime` emits nothing at all, including no `missed`. That gap is found by querying for the event that is absent, which is the same mechanism that detects any expected occurrence that never arrived.

## Design decisions

**Two times are carried, and both matter.** `scheduledTime` is the intended time; `context.timestamp` is when the occurrence happened. On `triggered`, the difference between them is the on-time-versus-late record. The producing scheduler or controller is identified by `context.source`, which every CDEvent already carries, so no separate field names it.

**`author` records attributed identity, not authenticated identity.** It is an addressing key: the actor the producing system attributes the action to. Proving the actor is the producer's responsibility.

**`target` carries a `type` alongside `id` and `source`,** so consumers can route on the kind of thing scheduled, and so target references are shaped consistently across subjects. `type` is a free string — `build`, `deployment`, `changeWindow` — rather than a closed enum, so the subject is not coupled to a fixed list of schedulable things.

**`triggeredExecution` is a field, not a link.** Replacing it with a relation link to the enqueued execution was considered. Linking is optional in CDEvents and an event should be complete without it: a consumer reading a `triggered` event should not have to consult a second mechanism to learn what was enqueued, particularly when the scheduler knows exactly what it just enqueued and can say so directly.

**The subject is treated as a sequence of actions, not a definition.** It was put to us that the lifecycle here is mostly definitional and might not warrant occurrence events. Registering a schedule is an action taken at a point in time by an identifiable actor, and it produces something that did not exist beforehand; canceling it removes that thing. Each is an occurrence an auditor may need to account for, and each is reported as it happens.

**No field for event publication time.** Publication timing is a property of the transport carrying the event, not of the thing that happened. The intended time and the occurrence time are both present already.

**No attempt identifier.** A retry is a new occurrence with its own identity. This is also not specific to `scheduledExecution`; if attempt identity is wanted, it belongs in the context for every subject.

**The `trigger` object is reused byte-identically** from the Testing vocabulary, including its existing `schedule` value. No new common objects are introduced.

## Out of scope

- **The authorization decision to create or amend a schedule.** `approval` already covers accountable authorization decisions. A schedule requiring sign-off is two occurrences.
- **Whether a fired execution is permitted to proceed.** Control-plane behavior. These events report that the schedule fired.

## Notes on this change

Event versions start at `0.1.0-draft`.

`schemas/_defs/` entries and `x-cdevents-semantics` are not included here. The predicate definitions this subject would need overlap with those already being added by #319 and with further subjects we are proposing; adding them here would collide. We will follow up with them once #319 lands.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved — *no new concept is introduced; this applies existing vocabulary patterns*
- [x] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [x] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning) — *new events start at `0.1.0-draft`; the spec version is unchanged*
- [x] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)
