### PR TITLE
feat(targetrollout): add targetRollout subject and queued/started/finished events

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -61,6 +61,7 @@ schemauri
 specversion
 src
 subjectid
+targetrollout
 taskrun
 testcase
 testcaserun

--- a/conformance/deployment_finished.json
+++ b/conformance/deployment_finished.json
@@ -1,0 +1,22 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.deployment.finished.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "environment": {
+        "id": "test123"
+      },
+      "outcome": "success"
+    }
+  }
+}

--- a/conformance/deployment_queued.json
+++ b/conformance/deployment_queued.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.deployment.queued.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "environment": {
+        "id": "test123"
+      }
+    }
+  }
+}

--- a/conformance/deployment_started.json
+++ b/conformance/deployment_started.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.deployment.started.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "environment": {
+        "id": "test123"
+      }
+    }
+  }
+}

--- a/conformance/targetrollout_finished.json
+++ b/conformance/targetrollout_finished.json
@@ -1,0 +1,25 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.targetrollout.finished.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "name": "us-east-1",
+      "target": "cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1",
+      "environment": {
+        "id": "test123"
+      },
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "deploymentId": "mySubject123",
+      "outcome": "success"
+    }
+  }
+}

--- a/conformance/targetrollout_queued.json
+++ b/conformance/targetrollout_queued.json
@@ -1,0 +1,24 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.targetrollout.queued.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "name": "us-east-1",
+      "target": "cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1",
+      "environment": {
+        "id": "test123"
+      },
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "deploymentId": "mySubject123"
+    }
+  }
+}

--- a/conformance/targetrollout_started.json
+++ b/conformance/targetrollout_started.json
@@ -1,0 +1,24 @@
+{
+  "context": {
+    "specversion": "0.6.0-draft",
+    "id": "271069a8-fc18-44f1-b38f-9d70a1695819",
+    "chainId": "4c8cb7dd-3448-41de-8768-eec704e2829b",
+    "source": "/event/source/123",
+    "type": "dev.cdevents.targetrollout.started.0.1.0",
+    "timestamp": "2023-03-20T14:27:05.315384Z",
+    "schemaUri": "https://myorg.com/schema/custom"
+  },
+  "subject": {
+    "id": "mySubject123",
+    "source": "/event/source/123",
+    "content": {
+      "name": "us-east-1",
+      "target": "cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1",
+      "environment": {
+        "id": "test123"
+      },
+      "artifactId": "pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427",
+      "deploymentId": "mySubject123"
+    }
+  }
+}

--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -14,12 +14,13 @@ Continuous Deployment (CD) events are related to continuous deployment pipelines
 
 ## Subjects
 
-This specification defines two subjects in this stage: `environment` and `service`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`.
+This specification defines three subjects in this stage: `environment`, `service`, and `deployment`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`. A `deployment` is the act of applying a version of a release unit to an environment.
 
 | Subject | Description | Predicates |
 |---------|-------------|------------|
 | [`environment`](#environment) | An environment where to run services | [`created`](#environment-created), [`modified`](#environment-modified), [`deleted`](#environment-deleted)|
 | [`service`](#service) | A service | [`deployed`](#service-deployed), [`upgraded`](#service-upgraded), [`rolledback`](#service-rolledback), [`removed`](#service-removed), [`published`](#service-published)|
+| [`deployment`](#deployment) | The act of deploying a release unit to an environment | [`queued`](#deployment-queued), [`started`](#deployment-started), [`finished`](#deployment-finished)|
 
 ### `environment`
 
@@ -42,6 +43,17 @@ A `service` can represent for example a binary that is running, a daemon, an app
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `staging/tekton`, `tekton-dev-123`|
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` |
 | artifactId | `Purl` | Identifier of the artifact deployed with this service |  `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427`, `pkg:golang/mygit.com/myorg/myapp@234fd47e07d1004f0aed9c` |
+
+### `deployment`
+
+A `deployment` is the act of applying a version of a release unit to an environment. A deployment is a canonical SDLC fact: it represents the change to the running system that resulted from a release, as distinct in meaning from the orchestration that performed it (see [`pipelineRun`](core.md#pipelinerun)). Where a producer's pipeline execution is itself the natural deployment boundary, its `id` MAY be reused as the `deployment` subject's `id`.
+
+| Field | Type | Description | Examples |
+|-------|------|-------------|----------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `/cd/deploy-controller` |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` |
 
 ## Events
 
@@ -147,6 +159,52 @@ This event represents the removal of a previously deployed service instance and 
 | id    | `String` | See [id](spec.md#id-subject)| `service/myapp`, `daemonset/myapp` | ✅ |
 | source | `URI-Reference` | See [source](spec.md#source-subject) | | |
 | environment | `Object` ([`environment`](#environment)) | Reference for the environment where the service runs | `{"id": "1234"}`, `{"id": "maven123, "source": "tekton-dev-123"}` | ✅ |
+
+### [`deployment queued`](conformance/deployment_queued.json)
+
+This event represents a deployment that has been accepted and is waiting to begin.
+
+- Event Type: __`dev.cdevents.deployment.queued.0.1.0`__
+- Predicate: queued
+- Subject: [`deployment`](#deployment)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
+
+### [`deployment started`](conformance/deployment_started.json)
+
+This event represents a deployment controller that has begun orchestrating a rollout.
+
+- Event Type: __`dev.cdevents.deployment.started.0.1.0`__
+- Predicate: started
+- Subject: [`deployment`](#deployment)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
+
+### [`deployment finished`](conformance/deployment_finished.json)
+
+This event represents a deployment that has completed. `deployment.finished` is the orchestration-side completion fact for a deployment, analogous to `build finished` on the CI side, and is kept separate from the entity-side fact carried by `service.deployed`.
+
+- Event Type: __`dev.cdevents.deployment.finished.0.1.0`__
+- Predicate: finished
+- Subject: [`deployment`](#deployment)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `dep-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
+| outcome | `String (enum)` | Outcome of the finished deployment | `success`, `failure`, `cancel`, `error` | ✅ |
 
 ### [`service published`](conformance/service_published.json)
 

--- a/continuous-deployment.md
+++ b/continuous-deployment.md
@@ -14,13 +14,14 @@ Continuous Deployment (CD) events are related to continuous deployment pipelines
 
 ## Subjects
 
-This specification defines three subjects in this stage: `environment`, `service`, and `deployment`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`. A `deployment` is the act of applying a version of a release unit to an environment.
+This specification defines four subjects in this stage: `environment`, `service`, `deployment`, and `targetRollout`. The term `service` is used to represent a running Artifact. A `service` can represent a binary that is running, a daemon, an application, a docker container. The term `environment` represent any platform which has all the means to run a `service`. A `deployment` is the aggregate act of applying a version of a release unit to one or more `targetRollout`s, and a `targetRollout` is a specific destination within an environment to which a release unit is deployed.
 
 | Subject | Description | Predicates |
 |---------|-------------|------------|
 | [`environment`](#environment) | An environment where to run services | [`created`](#environment-created), [`modified`](#environment-modified), [`deleted`](#environment-deleted)|
 | [`service`](#service) | A service | [`deployed`](#service-deployed), [`upgraded`](#service-upgraded), [`rolledback`](#service-rolledback), [`removed`](#service-removed), [`published`](#service-published)|
-| [`deployment`](#deployment) | The act of deploying a release unit to an environment | [`queued`](#deployment-queued), [`started`](#deployment-started), [`finished`](#deployment-finished)|
+| [`deployment`](#deployment) | The aggregate act of deploying a release unit to one or more target rollouts | [`queued`](#deployment-queued), [`started`](#deployment-started), [`finished`](#deployment-finished)|
+| [`targetRollout`](#targetrollout) | A specific deployment destination within an environment | [`queued`](#targetrollout-queued), [`started`](#targetrollout-started), [`finished`](#targetrollout-finished)|
 
 ### `environment`
 
@@ -46,7 +47,7 @@ A `service` can represent for example a binary that is running, a daemon, an app
 
 ### `deployment`
 
-A `deployment` is the act of applying a version of a release unit to an environment. A deployment is a canonical SDLC fact: it represents the change to the running system that resulted from a release, as distinct in meaning from the orchestration that performed it (see [`pipelineRun`](core.md#pipelinerun)). Where a producer's pipeline execution is itself the natural deployment boundary, its `id` MAY be reused as the `deployment` subject's `id`.
+A `deployment` is the act of applying a version of a release unit to one or more target rollouts. A deployment is a canonical SDLC fact: it represents the change to the running system that resulted from a release, as distinct in meaning from the orchestration that performed it (see [`pipelineRun`](core.md#pipelinerun)). Where a producer's pipeline execution is itself the natural deployment boundary, its `id` MAY be reused as the `deployment` subject's `id`. A deployment fans out to one or more [`targetRollout`](#targetrollout)s.
 
 | Field | Type | Description | Examples |
 |-------|------|-------------|----------|
@@ -54,6 +55,20 @@ A `deployment` is the act of applying a version of a release unit to an environm
 | source | `URI-Reference` | See [source](spec.md#source-subject) | `/cd/deploy-controller` |
 | artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` |
 | environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` |
+
+### `targetRollout`
+
+A `targetRollout` is a specific destination within an environment to which a release unit may be deployed and made available, for example a Kubernetes namespace in a particular region, or a named blue/green slot. A `targetRollout` is always contained within an environment, and multiple target rollouts may exist within a single environment. Each `targetRollout` carries a `deploymentId` reference back to its parent [`deployment`](#deployment). This also gives [`environment`](#environment) a first-class inbound link to what has been deployed into it: `environment created`/`modified`/`deleted` describe the platform alone, and previously the only way to associate an environment with what is running in it was to inspect `service` events, where the reference points the other way, from the entity back down to the environment it happens to run in. `targetRollout` events point from the act of deploying to the destination, so "what was rolled out to this environment" is a direct query rather than an inference over `service` events.
+
+| Field | Type | Description | Examples |
+|-------|------|-------------|----------|
+| id    | `String` | See [id](spec.md#id-subject)| `rt-us-east-1-8f3a2c` |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | `/cd/deploy-controller` |
+| name | `String` | Name of the target rollout | `canary`, `us-east-1`, `blue-slot` |
+| target | `URI-Reference` | Location identifier of where the artifact is being deployed to | `cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1` |
+| environment | `Object` ([`environment`](#environment)) | Reference to the containing environment | `{"id": "production"}` |
+| artifactId | `Purl` | Identifier of the artifact being deployed to this target | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` |
+| deploymentId | `String` | Reference to the parent [`deployment`](#deployment) | `dep-8f3a2c` |
 
 ## Events
 
@@ -192,7 +207,7 @@ This event represents a deployment controller that has begun orchestrating a rol
 
 ### [`deployment finished`](conformance/deployment_finished.json)
 
-This event represents a deployment that has completed. `deployment.finished` is the orchestration-side completion fact for a deployment, analogous to `build finished` on the CI side, and is kept separate from the entity-side fact carried by `service.deployed`.
+This event represents a deployment that has completed across all of its target rollouts. `deployment.finished` is the orchestration-side completion fact for a deployment, analogous to `build finished` on the CI side, and is kept separate from the entity-side fact carried by `service.deployed`. Failure semantics are all-or-nothing: if any target rollout fails, `deployment.finished` has `outcome: failure`. Consumers needing per-destination detail should inspect the individual [`targetRollout finished`](#targetrollout-finished) events.
 
 - Event Type: __`dev.cdevents.deployment.finished.0.1.0`__
 - Predicate: finished
@@ -205,6 +220,62 @@ This event represents a deployment that has completed. `deployment.finished` is 
 | artifactId | `Purl` | Identifier of the artifact being deployed | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
 | environment | `Object` ([`environment`](#environment)) | Reference to the target environment | `{"id": "production"}` | ✅ |
 | outcome | `String (enum)` | Outcome of the finished deployment | `success`, `failure`, `cancel`, `error` | ✅ |
+
+### [`targetRollout queued`](conformance/targetrollout_queued.json)
+
+This event represents a deployment to a specific target rollout that has been scheduled.
+
+- Event Type: __`dev.cdevents.targetrollout.queued.0.1.0`__
+- Predicate: queued
+- Subject: [`targetRollout`](#targetrollout)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `rt-us-east-1-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| name | `String` | Name of the target rollout | `canary`, `us-east-1`, `blue-slot` | ✅ |
+| target | `URI-Reference` | Location identifier of where the artifact is being deployed to | `cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the containing environment | `{"id": "production"}` | ✅ |
+| artifactId | `Purl` | Identifier of the artifact being deployed to this target | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| deploymentId | `String` | Reference to the parent [`deployment`](#deployment) | `dep-8f3a2c` | |
+
+### [`targetRollout started`](conformance/targetrollout_started.json)
+
+This event represents a deployment to a specific target rollout that has begun.
+
+- Event Type: __`dev.cdevents.targetrollout.started.0.1.0`__
+- Predicate: started
+- Subject: [`targetRollout`](#targetrollout)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `rt-us-east-1-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| name | `String` | Name of the target rollout | `canary`, `us-east-1`, `blue-slot` | ✅ |
+| target | `URI-Reference` | Location identifier of where the artifact is being deployed to | `cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the containing environment | `{"id": "production"}` | ✅ |
+| artifactId | `Purl` | Identifier of the artifact being deployed to this target | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| deploymentId | `String` | Reference to the parent [`deployment`](#deployment) | `dep-8f3a2c` | |
+
+### [`targetRollout finished`](conformance/targetrollout_finished.json)
+
+This event represents a deployment to a specific target rollout that has completed. `failureType` categorizes the failure reason when `outcome` is `failure`, letting consumers distinguish a policy gate, build, evaluation, deployment, or analysis failure without producer-specific convention.
+
+- Event Type: __`dev.cdevents.targetrollout.finished.0.1.0`__
+- Predicate: finished
+- Subject: [`targetRollout`](#targetrollout)
+
+| Field | Type | Description | Examples | Required |
+|-------|------|-------------|----------|----------------------------|
+| id    | `String` | See [id](spec.md#id-subject)| `rt-us-east-1-8f3a2c` | ✅ |
+| source | `URI-Reference` | See [source](spec.md#source-subject) | | |
+| name | `String` | Name of the target rollout | `canary`, `us-east-1`, `blue-slot` | ✅ |
+| target | `URI-Reference` | Location identifier of where the artifact is being deployed to | `cdevents:v0:argo::my-org:prod-cluster:environment:us-east-1` | ✅ |
+| environment | `Object` ([`environment`](#environment)) | Reference to the containing environment | `{"id": "production"}` | ✅ |
+| artifactId | `Purl` | Identifier of the artifact being deployed to this target | `pkg:oci/myapp@sha256%3A0b31b1c02ff458ad9b7b81cbdf8f028bd54699fa151f221d1e8de6817db93427` | ✅ |
+| deploymentId | `String` | Reference to the parent [`deployment`](#deployment) | `dep-8f3a2c` | |
+| outcome | `String (enum)` | Outcome of the finished target rollout | `success`, `failure`, `cancel`, `error` | ✅ |
+| failureType | `String (enum)` | Category of failure, only present when `outcome` is `failure` | `gate`, `build`, `evaluation`, `deployment`, `analysis` | |
 
 ### [`service published`](conformance/service_published.json)
 

--- a/schemas/_defs/deployment.json
+++ b/schemas/_defs/deployment.json
@@ -1,16 +1,18 @@
 {
   "$id": "cdevents/_defs/deployment",
   "term": "Deployment",
-  "definition": "A Deployment is the act of applying a version of a release unit to an environment. A deployment is a canonical SDLC fact, and it is not the pipeline that performed the deployment, but the change to the running system that resulted from it.",
+  "definition": "A Deployment is the act of applying a version of a release unit to one or more target rollouts. A deployment is a canonical SDLC fact, and it is not the pipeline that performed the deployment, but the change to the running system that resulted from it.",
   "notes": [
+    "A Deployment fans out to one or more TargetRollouts",
     "A Deployment is not the pipeline or tooling that executed it",
-    "deployment separates the orchestration act of deploying from the entity fact of a running service, mirroring the build/artifact split in CI"
+    "deployment/targetRollout separate the orchestration act of deploying from the entity fact of a running service, mirroring the build/artifact split in CI"
   ],
   "examples": [
-    "Deploying myapp v1.2.3 to the production environment",
-    "A Spinnaker pipeline execution that rolls out a service to a Kubernetes cluster"
+    "Deploying myapp v1.2.3 to the production environment across multiple regions",
+    "A Spinnaker pipeline execution that rolls out a service to multiple Kubernetes clusters"
   ],
   "counterExamples": [
-    "The pipeline that performed the deployment"
+    "The pipeline that performed the deployment",
+    "An individual rollout to a single target (that is a TargetRollout)"
   ]
 }

--- a/schemas/_defs/deployment.json
+++ b/schemas/_defs/deployment.json
@@ -1,0 +1,16 @@
+{
+  "$id": "cdevents/_defs/deployment",
+  "term": "Deployment",
+  "definition": "A Deployment is the act of applying a version of a release unit to an environment. A deployment is a canonical SDLC fact, and it is not the pipeline that performed the deployment, but the change to the running system that resulted from it.",
+  "notes": [
+    "A Deployment is not the pipeline or tooling that executed it",
+    "deployment separates the orchestration act of deploying from the entity fact of a running service, mirroring the build/artifact split in CI"
+  ],
+  "examples": [
+    "Deploying myapp v1.2.3 to the production environment",
+    "A Spinnaker pipeline execution that rolls out a service to a Kubernetes cluster"
+  ],
+  "counterExamples": [
+    "The pipeline that performed the deployment"
+  ]
+}

--- a/schemas/_defs/finished.json
+++ b/schemas/_defs/finished.json
@@ -1,0 +1,20 @@
+{
+  "$id": "cdevents/_defs/finished",
+  "term": "Finished",
+  "definition": "Indicates that execution of an entity has ended, regardless of outcome. The outcome field on the event conveys whether execution succeeded or failed.",
+  "notes": [
+    "A finished event does not imply successful execution.",
+    "The outcome field must be inspected to determine success or failure.",
+    "A finished event is terminal — no further lifecycle events follow for this entity."
+  ],
+  "examples": [
+    "A deployment completing across all target rollouts",
+    "A target rollout completing at its destination",
+    "A pipeline run terminating with success or failure"
+  ],
+  "counterExamples": [
+    "Intermediate execution states",
+    "Progress or partial completion signals",
+    "Cancellation requests (the finished event is emitted after cancellation is complete)"
+  ]
+}

--- a/schemas/_defs/queued.json
+++ b/schemas/_defs/queued.json
@@ -1,0 +1,18 @@
+{
+  "$id": "cdevents/_defs/queued",
+  "term": "Queued",
+  "definition": "Indicates that an entity has been accepted and is waiting to begin execution.",
+  "notes": [
+    "A queued event does not imply that execution has started.",
+    "The associated entity may be held by scheduling, resource availability, or dependencies."
+  ],
+  "examples": [
+    "A deployment accepted by a deploy controller and waiting for resources",
+    "A target rollout scheduled but not yet executing",
+    "A pipeline run waiting in a queue before a worker picks it up"
+  ],
+  "counterExamples": [
+    "Active execution of the entity",
+    "Completion or failure of the entity"
+  ]
+}

--- a/schemas/_defs/targetrollout.json
+++ b/schemas/_defs/targetrollout.json
@@ -1,0 +1,20 @@
+{
+  "$id": "cdevents/_defs/targetrollout",
+  "term": "TargetRollout",
+  "definition": "A TargetRollout is a specific destination within an environment to which a release unit may be deployed and made available. A TargetRollout is always contained within an environment. Multiple TargetRollouts may exist within a single environment.",
+  "notes": [
+    "A TargetRollout carries a deploymentId reference back to its parent Deployment",
+    "A TargetRollout represents a single deployment destination, not an environment",
+    "failureType is available on targetRollout.finished to express per-destination failure reasons",
+    "TargetRollout gives Environment a first-class inbound link to what was deployed into it, rather than relying on Service's backwards-pointing environment reference"
+  ],
+  "examples": [
+    "A Kubernetes namespace in us-east-1 within the production environment",
+    "A canary slot within a blue/green deployment",
+    "A named deployment slot in a cloud provider region"
+  ],
+  "counterExamples": [
+    "An environment itself",
+    "The aggregate deployment across all targets (that is a Deployment)"
+  ]
+}

--- a/schemas/deploymentfinished.json
+++ b/schemas/deploymentfinished.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/deployment-finished-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/deployment",
+    "predicate": "cdevents/_defs/finished"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.deployment.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.deployment.finished.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "outcome": {
+              "type": "string",
+              "enum": [
+                "success",
+                "failure",
+                "cancel",
+                "error"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "artifactId",
+            "environment",
+            "outcome"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/deploymentqueued.json
+++ b/schemas/deploymentqueued.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/deployment-queued-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/deployment",
+    "predicate": "cdevents/_defs/queued"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.deployment.queued.0.1.0"
+          ],
+          "default": "dev.cdevents.deployment.queued.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "artifactId",
+            "environment"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/deploymentstarted.json
+++ b/schemas/deploymentstarted.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/deployment-started-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/deployment",
+    "predicate": "cdevents/_defs/started"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.deployment.started.0.1.0"
+          ],
+          "default": "dev.cdevents.deployment.started.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "artifactId",
+            "environment"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/targetrolloutfinished.json
+++ b/schemas/targetrolloutfinished.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/targetrollout-finished-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/targetrollout",
+    "predicate": "cdevents/_defs/finished"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.targetrollout.finished.0.1.0"
+          ],
+          "default": "dev.cdevents.targetrollout.finished.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri-reference"
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "deploymentId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "outcome": {
+              "type": "string",
+              "enum": [
+                "success",
+                "failure",
+                "cancel",
+                "error"
+              ]
+            },
+            "failureType": {
+              "type": "string",
+              "enum": [
+                "gate",
+                "build",
+                "evaluation",
+                "deployment",
+                "analysis"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "name",
+            "target",
+            "environment",
+            "artifactId",
+            "outcome"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/targetrolloutqueued.json
+++ b/schemas/targetrolloutqueued.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/targetrollout-queued-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/targetrollout",
+    "predicate": "cdevents/_defs/queued"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.targetrollout.queued.0.1.0"
+          ],
+          "default": "dev.cdevents.targetrollout.queued.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri-reference"
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "deploymentId": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "name",
+            "target",
+            "environment",
+            "artifactId"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}

--- a/schemas/targetrolloutstarted.json
+++ b/schemas/targetrolloutstarted.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdevents.dev/0.6.0-draft/schema/targetrollout-started-event",
+  "x-cdevents-semantics": {
+    "subject": "cdevents/_defs/targetrollout",
+    "predicate": "cdevents/_defs/started"
+  },
+  "properties": {
+    "context": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "dev.cdevents.targetrollout.started.0.1.0"
+          ],
+          "default": "dev.cdevents.targetrollout.started.0.1.0"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "schemaUri": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri"
+        },
+        "chainId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "links/embeddedlinksarray"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "source",
+        "type",
+        "timestamp"
+      ]
+    },
+    "subject": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "format": "uri-reference"
+        },
+        "content": {
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target": {
+              "type": "string",
+              "minLength": 1,
+              "format": "uri-reference"
+            },
+            "environment": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "source": {
+                  "type": "string",
+                  "minLength": 1,
+                  "format": "uri-reference"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "id"
+              ]
+            },
+            "artifactId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "deploymentId": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "name",
+            "target",
+            "environment",
+            "artifactId"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "content"
+      ]
+    },
+    "customData": {
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      ]
+    },
+    "customDataContentType": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "context",
+    "subject"
+  ]
+}


### PR DESCRIPTION
Follow-up to #319 (`deployment.queued/started/finished`), per @afrittoli's review: landing `deployment` on its own first, with `targetRollout` proposed separately here now that there's a concrete use case and one open PR of implementation experience to point to.

## What this adds

`targetRollout` — a specific destination within a `deployment`'s environment (a region, canary slot, or named blue/green slot) — with the standard `queued`/`started`/`finished` lifecycle, a `deploymentId` back-reference to its parent `deployment`, and `failureType` on `finished` for per-destination failure detail.

## Why this isn't a new execution model

The concern raised on #319 was that giving `targetRollout` its own independent lifecycle "encodes one execution model." But this is the same shape the spec already has for `pipelineRun`/`taskRun`: a parent orchestration entity fans out to child execution units, each with its own `queued`/`started`/`finished`. `targetRollout` under `deployment` is that same pattern, not a new one. A producer that genuinely fans a deployment out to multiple destinations already has to track per-destination timing to coordinate the rollout in the first place — this just gives that internal fact a standard external shape. A producer that deploys to exactly one destination, or that calls a single atomic multi-region API with no per-destination visibility, simply doesn't emit `targetRollout` — same as any other optional CDEvents subject.

`targetRollout` also gives `environment` a first-class inbound link to what was deployed into it — today the only way to find out what's running in an environment is to scan `service` events and filter on `content.environment.id`, a reference that points the wrong way for that query.

Depends on #319 — this diff will be just the `targetRollout` additions once that merges.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has the [primer doc](https://github.com/cdevents/cdevents.dev/blob/main/content/en/docs/primer/_index.md) been updated if a design decision is involved
- [ ] Have the [JSON schemas](https://github.com/cdevents/spec/tree/main/schemas) been updated if the specification changed
- [ ] Has spec version and event versions been updated according to the [versioning policy](https://cdevents.dev/docs/primer/#versioning)
- [ ] Meets the [CDEvents contributor standards](https://github.com/cdevents/.github/blob/main/docs/CONTRIBUTING.md)