### PR TITLE
Add spinnaker to the provider registry

### DIFF
--- a/schemas/registry/providers.json
+++ b/schemas/registry/providers.json
@@ -20,6 +20,7 @@
     "linear",
     "nexus",
     "pagerduty",
-    "tekton"
+    "tekton",
+    "spinnaker"
   ]
 }


### PR DESCRIPTION
## Summary
- Register `spinnaker` in the CDEvents provider registry (`schemas/registry/providers.json`), added at the end of the enum per repo convention to keep the list append-only and generator-stable.

## Test plan
- [ ] Confirm `spinnaker` validates as a `provider` value per `pattern` in the schema